### PR TITLE
US-04.1.1: Tasca 5: Actualitzar la base de dades amb privacitat i llista de sol·licituds

### DIFF
--- a/api/app/routers/users.py
+++ b/api/app/routers/users.py
@@ -24,7 +24,7 @@ router = APIRouter(prefix="/users", tags=["Users"])
 async def register_user(data: dict, user=Depends(verify_token)):
     """
     Desa un nou usuari al Firestore després de registre al Firebase Auth.
-    El frontend envia fullname, username, mail, i el backend completa els defaults.
+    El frontend envia fullname, username, mail i isPrivate, i el backend completa els defaults.
     """
     uid = user.get("uid")
     if not uid:
@@ -45,6 +45,7 @@ async def register_user(data: dict, user=Depends(verify_token)):
         "url_foto_perfil": data.get("url_foto_perfil", ""),
         "url_foto_panell": data.get("url_foto_panell", ""),
         "premium": data.get("premium", False),
+        "isPrivate": data.get("isPrivate", False),
         "llista_bloquejats": data.get("llista_bloquejats", []),
         "llista_bloquejadors": data.get("llista_bloquejadors", []),
     }
@@ -95,6 +96,7 @@ class UserEditIn(BaseModel):
     username: Optional[str] = None
     url_foto_perfil: Optional[str] = None
     url_foto_panell: Optional[str] = None
+    isPrivate: Optional[bool] = None
 
 
 # (PATCH = modificació parcial)

--- a/api/app/routers/users.py
+++ b/api/app/routers/users.py
@@ -42,6 +42,8 @@ async def register_user(data: dict, user=Depends(verify_token)):
         "guardades": data.get("guardades", []),
         "llista_seguidors": data.get("lista_seguidores", []),
         "llista_seguits": data.get("lista_seguidos", []),
+        "llista_solicitud_seguidors": data.get("llista_solicitud_seguidor", []),
+        "llista_solicitud_seguits": data.get("llista_solicitud_seguits", []),
         "url_foto_perfil": data.get("url_foto_perfil", ""),
         "url_foto_panell": data.get("url_foto_panell", ""),
         "premium": data.get("premium", False),
@@ -176,11 +178,48 @@ async def unfollow_user(user_id: str, target_id: str):
     return {"message": "Has deixat de seguir l'usuari correctament"}
 
 
+@router.post("/cancel_follow_request/{user_id}/{target_id}")
+async def cancel_follow_request(user_id: str, target_id: str):
+    """
+    Cancel·la una sol·licitud de seguiment pendent.
+    Elimina user_id de llista_solicitud_seguidors del target_id.
+    Elimina target_id de llista_solicitud_seguits del user_id.
+    """
+    user_ref = db.collection("users").document(user_id)
+    target_ref = db.collection("users").document(target_id)
+
+    user_doc = user_ref.get()
+    target_doc = target_ref.get()
+
+    # Comprovem que l'usuari existeix
+    if not user_doc.exists:
+        raise HTTPException(
+            status_code=404, detail="L'usuari que intenta cancel·lar la sol·licitud no existeix"
+        )
+
+    # Comprovem que l'usuari target existeix
+    if not target_doc.exists:
+        raise HTTPException(
+            status_code=404, detail="L'usuari target no existeix"
+        )
+
+    # Eliminar de la llista de sol·licituds enviades
+    user_ref.update({"llista_solicitud_seguits": firestore.ArrayRemove([target_id])})
+
+    # Eliminar de la llista de sol·licituds rebudes
+    target_ref.update({"llista_solicitud_seguidors": firestore.ArrayRemove([user_id])})
+
+    return {"message": "Sol·licitud de seguiment cancel·lada correctament"}
+
+
 @router.post("/follow/{user_id}/{target_id}")
 async def follow_user(user_id: str, target_id: str):
     """
     Afegeix el target_id a la llista 'llista_seguits' del user_id,
     i afegeix el user_id a la llista 'llista_seguidors' del target_id.
+    
+    Si el target té perfil privat, crea una sol·licitud de seguiment.
+    Si el target té perfil públic, segueix directament.
     """
     if user_id == target_id:
         raise HTTPException(status_code=400, detail="No et pots seguir a tu mateix")
@@ -189,18 +228,26 @@ async def follow_user(user_id: str, target_id: str):
     target_ref = db.collection("users").document(target_id)
 
     # Comprovació que l'usuari a seguir existeix
-    if not target_ref.get().exists:
+    target_doc = target_ref.get()
+    if not target_doc.exists:
         raise HTTPException(
             status_code=404, detail="L'usuari que vols seguir no existeix"
         )
 
-    # Afegir a la llista de seguits
-    user_ref.update({"llista_seguits": firestore.ArrayUnion([target_id])})
+    # Verificar si el target té perfil privat
+    target_data = target_doc.to_dict()
+    is_private = target_data.get("isPrivate", False)
 
-    # Afegir a la llista de seguidors
-    target_ref.update({"llista_seguidors": firestore.ArrayUnion([user_id])})
-
-    return {"message": "Usuari seguit correctament"}
+    if is_private:
+        # Si és privat, crear una sol·licitud de seguiment
+        target_ref.update({"llista_solicitud_seguidors": firestore.ArrayUnion([user_id])})
+        user_ref.update({"llista_solicitud_seguits": firestore.ArrayUnion([target_id])})
+        return {"message": "Sol·licitud de seguiment enviada correctament"}
+    else:
+        # Si és públic, seguir directament
+        user_ref.update({"llista_seguits": firestore.ArrayUnion([target_id])})
+        target_ref.update({"llista_seguidors": firestore.ArrayUnion([user_id])})
+        return {"message": "Usuari seguit correctament"}
 
 
 @router.post("/save/{user_id}/{trip_id}")

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -77,6 +77,11 @@ export async function unfollowUser(userId: string, targetId: string) {
   return apiPost(`/users/unfollow/${userId}/${targetId}`, {});
 }
 
+// Eliminar sol·licitud de seguiment
+export async function cancel_follow_request(userId: string, targetId: string) {
+  return apiPost(`/users/cancel_follow_request/${userId}/${targetId}`, {});
+}
+
 // Guardar una ruta
 export async function saveTrip(userId: string, tripId: string) {
   return apiPost(`/users/save/${userId}/${tripId}`, {});

--- a/frontend/src/components/UserSettings.tsx
+++ b/frontend/src/components/UserSettings.tsx
@@ -5,14 +5,15 @@ import { auth } from "../firebase";
 import { signOut } from "firebase/auth";
 import { deleteAccount } from "../api/client";
 import i18n from "../i18n/i18n";
-import { useTranslation } from 'react-i18next'; // Importa el hook
+import { useTranslation } from 'react-i18next';
+import type { BackendUser } from "../pages/UserProfile";
 
 
 type Props = {
   open: boolean;
   onClose: () => void;
-  isPrivate: boolean;
-  onChangePrivacy: (value: boolean) => void;
+  profile: BackendUser;
+  onSavePrivacy?: (updatedProfile: BackendUser) => void;
 };
 
 // Funció per decidir tema inicial (localStorage o preferència del sistema)
@@ -26,7 +27,7 @@ function getInitialTheme(): "light" | "dark" {
   return prefersDark ? "dark" : "light";
 }
 
-export default function UserSettings({ open, onClose, isPrivate, onChangePrivacy }: Props) {
+export default function UserSettings({ open, profile, onClose, onSavePrivacy }: Props) {
   const { t } = useTranslation();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
@@ -35,14 +36,16 @@ export default function UserSettings({ open, onClose, isPrivate, onChangePrivacy
 
   const [language, setLanguage] = useState(i18n.language || "ca");
 
+  const [privacyLoading, setPrivacyLoading] = useState(false);
+  const [isPrivate, setIsPrivate] = useState(profile.isPrivate || false);
+
   const changeLanguage = (lng: string) => {
       i18n.changeLanguage(lng);
       setLanguage(lng);
       localStorage.setItem("lang", lng);
   };
 
-
-    // Cada cop que canvia el tema → actualitzem l'HTML i el guardem
+  // Cada cop que canvia el tema → actualitzem l'HTML i el guardem
   useEffect(() => {
     document.documentElement.setAttribute("data-theme", theme);
     localStorage.setItem("theme", theme);
@@ -50,6 +53,50 @@ export default function UserSettings({ open, onClose, isPrivate, onChangePrivacy
 
   const toggleTheme = () => {
     setTheme((prev) => (prev === "light" ? "dark" : "light"));
+  };
+
+  const handleChangePrivacy = async (newPrivacy: boolean) => {
+    try {
+      setPrivacyLoading(true);
+      setError("");
+
+      const formData = new FormData();
+
+      const jsonData = {
+        isPrivate: newPrivacy,
+      };
+
+      // FastAPI requereix user_json com string
+      formData.append("user_json", JSON.stringify(jsonData));
+
+      const response = await fetch(
+        `http://127.0.0.1:8000/users/update/${profile.uid}`,
+        {
+          method: "PATCH",
+          body: formData,
+        }
+      );
+
+      if (!response.ok) {
+        const err = await response.json();
+        throw new Error(err.detail || t('profile_error_updating'));
+      }
+
+      // Actualitzem l'estat local
+      setIsPrivate(newPrivacy);
+
+      const updatedProfile: BackendUser = {
+        ...profile,
+        isPrivate: newPrivacy,
+      };
+
+      if (onSavePrivacy) onSavePrivacy(updatedProfile);
+    } catch (e: any) {
+      console.error(t('error'), e);
+      setError(e?.message || t('profile_error_updating'));
+    } finally {
+      setPrivacyLoading(false);
+    }
   };
 
   if (!open) return null;
@@ -147,13 +194,14 @@ export default function UserSettings({ open, onClose, isPrivate, onChangePrivacy
                 </span>
               </div>
 
-              {/* Toggle senzill per privacitat (reutilitza l’estil) */}
+              {/* Toggle senzill per privacitat (reutilitza l'estil) */}
               <label className="toggle-wrapper">
                 <input
                   type="checkbox"
                   className="toggle-checkbox"
                   checked={isPrivate}
-                  onChange={(e) => onChangePrivacy(e.target.checked)}
+                  onChange={(e) => handleChangePrivacy(e.target.checked)}
+                  disabled={privacyLoading}
                 />
                 <div className="toggle-slot">
                   <div className="toggle-button" />

--- a/frontend/src/pages/UserProfile.tsx
+++ b/frontend/src/pages/UserProfile.tsx
@@ -153,12 +153,12 @@ export default function UserProfile() {
   const toGridItems = (trips: Trip[]): GridItem[] =>
     trips.map((t) => ({
       id: String(t._id),
-      title: t.title || t('general_no_title'),
+      title: t.title || ('general_no_title'),
       img:
         t.coverImage ||
         (t.gallery && t.gallery[0]) ||
         "https://placehold.co/600x400?text=Ruta+Sense+Imatge",
-      user: t.author?.name || t('general_anonymous'),
+      user: t.author?.name || ('general_anonymous'),
       rating: typeof t.avgRating === "number" ? t.avgRating : 0,
       temps: t.duration || "—",
       dificultat: t.difficulty || "—",
@@ -385,10 +385,8 @@ export default function UserProfile() {
           <UserSettings 
             open={settingsOpen} 
             onClose={() => setSettingsOpen(false)}
-            isPrivate={!!profile.isPrivate}
-            onChangePrivacy={(value) =>
-              setProfile((prev) => (prev ? { ...prev, isPrivate: value } : prev))
-            }
+            profile={profile}
+            onSavePrivacy={(updatedProfile) => setProfile(updatedProfile)}
           />
 
           {openEdit && profile && (


### PR DESCRIPTION
Quan es registra un nou usuari, ara aquest ha d'escollir l'estat de privacitat del seu perfil (públic o privat). 

Aquest estat es pot modificar en qualsevl moment des de la configuració del perfil.

Pròximament, quan un usuari vulgui seguir un compte privat haurà de demanar sol·licitud de seguiment. Per aquest motiu, també s'han creat endpoints amb les funcions corresponents a la API per afegir i treure usuaris de llistes de sol·licituds pendents.

Classes modificades:
- frontend/src/pages/UserProfile.tsx
- frontend/src/components/UserSettings.tsx
- frontend/src/api/client.ts
- api/app/routers/users.py