### PR TITLE
US-04.1.1: Tasca 6: Modificar handler botó seguiment

### DIFF
--- a/frontend/src/i18n/ca.json
+++ b/frontend/src/i18n/ca.json
@@ -27,6 +27,7 @@
   "route_detail_followers": "seguidor",
   "route_detail_followers_plural": "seguidors",
   "route_detail_following": "Seguint",
+  "route_detail_pending": "Pendent",
   "route_detail_follow": "Seguir",
   "route_detail_description_title": "Descripció",
   "route_detail_stages_title": "Etapes de la Ruta",
@@ -71,6 +72,9 @@
   "profile_public_login_follow_hint": "Has d'iniciar sessió per seguir usuaris",
   "profile_error_unfollowing": "Error seguint/seguint deixant:",
   "profile_have_to_login": "Has de iniciar sessió per interactuar",
+  "user_profile_follow": "Seguir",
+  "user_profile_following": "Seguint",
+  "user_profile_pending": "Pendent",
 
   "general_home": "Pàgina principal",
   "general_loading": "Carregant...",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -27,6 +27,7 @@
   "route_detail_followers": "follower",
   "route_detail_followers_plural": "followers",
   "route_detail_following": "Following",
+  "route_detail_pending": "Pending",
   "route_detail_follow": "Follow",
   "route_detail_description_title": "Description",
   "route_detail_stages_title": "Route Stages",
@@ -64,6 +65,9 @@
   "profile_public_error_not_found": "User not found",
   "profile_public_error_loading": "Could not load profile.",
   "profile_public_login_follow_hint": "You must log in to follow users",
+  "user_profile_follow": "Follow",
+  "user_profile_following": "Following",
+  "user_profile_pending": "Pending",
 
   "general_home": "Home Page",
   "general_loading": "Loading...",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -27,6 +27,7 @@
   "route_detail_followers": "seguidor",
   "route_detail_followers_plural": "seguidores",
   "route_detail_following": "Siguiendo",
+  "route_detail_pending": "Pendiente",
   "route_detail_follow": "Seguir",
   "route_detail_description_title": "Descripción",
   "route_detail_stages_title": "Etapas de la Ruta",
@@ -64,6 +65,9 @@
   "profile_public_error_not_found": "Usuario no encontrado",
   "profile_public_error_loading": "No se ha podido cargar el perfil.",
   "profile_public_login_follow_hint": "Debes iniciar sesión para seguir usuarios",
+  "user_profile_follow": "Seguir",
+  "user_profile_following": "Siguiendo",
+  "user_profile_pending": "Pendiente",
 
   "general_home": "Página principal",
   "general_loading": "Cargando...",

--- a/frontend/src/pages/RutaDetall.tsx
+++ b/frontend/src/pages/RutaDetall.tsx
@@ -27,6 +27,7 @@ import {
   unfollowUser,
   saveTrip,
   unsaveTrip,
+  cancel_follow_request,
 } from "../api/client";
 
 import "dayjs/locale/ca";
@@ -50,6 +51,8 @@ export default function RutaDetall() {
 
   const [followersCount, setFollowersCount] = useState<number | null>(null);
   const [isFollowing, setIsFollowing] = useState(false);
+  const [isPending, setIsPending] = useState(false);
+  const [isPrivate, setIsPrivate] = useState(false);
   const [followLoading, setFollowLoading] = useState(false);
 
   const [isSaved, setIsSaved] = useState(false);
@@ -131,10 +134,17 @@ export default function RutaDetall() {
           : 0;
 
         setFollowersCount(count);
+        setIsPrivate(author.isPrivate || false);
 
         if (currentUser) {
           const followersList: string[] = author.llista_seguidors || [];
-          setIsFollowing(followersList.includes(currentUser.uid));
+          const isFollowingNow = followersList.includes(currentUser.uid);
+          setIsFollowing(isFollowingNow);
+
+          // Comprovar si hi ha sol·licitud de seguiment pendent
+          const solicituds = author.llista_solicitud_seguidors || [];
+          const hasSolicited = solicituds.includes(currentUser.uid);
+          setIsPending(hasSolicited && !isFollowingNow);
 
           const currentUserData = await getUserById(currentUser.uid);
           const savedTrips: string[] = currentUserData.guardades || [];
@@ -158,14 +168,26 @@ export default function RutaDetall() {
     try {
       setFollowLoading(true);
 
-      if (!isFollowing) {
+      if (!isFollowing && !isPending) {
+        // Seguir l'usuari
         await followUser(userId, targetId);
-        setIsFollowing(true);
-        setFollowersCount((v) => (v ?? 0) + 1);
-      } else {
+        
+        // Si és privat, mostrar pendent; si és públic, mostrar following
+        if (isPrivate) {
+          setIsPending(true);
+        } else {
+          setIsFollowing(true);
+          setFollowersCount((v) => (v ?? 0) + 1);
+        }
+      } else if (isFollowing) {
+        // Deixar de seguir
         await unfollowUser(userId, targetId);
         setIsFollowing(false);
         setFollowersCount((v) => Math.max(0, (v ?? 0) - 1));
+      } else if (isPending) {
+        // Cancelar sol·licitud pendent
+        await cancel_follow_request(userId, targetId);
+        setIsPending(false);
       }
     } catch (err) {
       console.error(t('route_detail_error_following'), err);
@@ -356,11 +378,11 @@ export default function RutaDetall() {
 
           {currentUser && currentUser.uid !== tripData.author.userId && (
             <button
-              className={`follow-button ${isFollowing ? "following" : ""}`}
+              className={`follow-button ${isFollowing ? "following" : isPending ? "pending" : ""}`}
               disabled={followLoading}
               onClick={handleFollow}
             >
-              {isFollowing ? t('route_detail_following') : t('route_detail_follow')}
+              {isFollowing ? t('route_detail_following') : isPending ? t('route_detail_pending') : t('route_detail_follow')}
             </button>
           )}
         </div>

--- a/frontend/src/pages/UserProfilePublic.tsx
+++ b/frontend/src/pages/UserProfilePublic.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { onAuthStateChanged, type User as FirebaseUser, signOut } from "firebase/auth";
 import { useNavigate, useParams } from "react-router-dom";
 import { auth } from "../firebase";
-import { getUserById, followUser, unfollowUser, blockUser, unblockUser } from "../api/client";
+import { getUserById, followUser, unfollowUser, blockUser, unblockUser, cancel_follow_request } from "../api/client";
 import { getAllTrips, type Trip } from "../api/trips";
 import "../styles/UserProfile.css";
 import { ImageOff, UserX } from "lucide-react";
@@ -24,6 +24,7 @@ export type BackendUser = {
   seguits?: number;
   llista_seguidors?: string[];
   llista_seguits?: string[];
+  llista_solicitud_seguidors?: string[];
   publicacions?: string[];
   url_foto_perfil?: string;
   url_foto_panell?: string;
@@ -110,7 +111,7 @@ export default function UserProfilePublic() {
     fetchProfile();
   }, [id, t]);
 
-  // Saber si el currentUser segueix aquest perfil
+  // Saber si el currentUser segueix aquest perfil o ha sol·licitat seguir-lo
   useEffect(() => {
     if (!currentUser || !profile) {
       setIsFollowing(false);
@@ -121,8 +122,18 @@ export default function UserProfilePublic() {
     const followers = profile.llista_seguidors || [];
     const alreadyFollowing = followers.includes(currentUser.uid);
 
+    const solicituds = profile.llista_solicitud_seguidors || [];
+    const hasSolicited = solicituds.includes(currentUser.uid);
+
     setIsFollowing(alreadyFollowing);
-    setFollowStatus(alreadyFollowing ? "following" : "none");
+    
+    if (alreadyFollowing) {
+      setFollowStatus("following");
+    } else if (hasSolicited) {
+      setFollowStatus("pending");
+    } else {
+      setFollowStatus("none");
+    }
   }, [currentUser, profile]);
 
   // Saber si l'hem bloquejat (Staging)
@@ -163,53 +174,44 @@ export default function UserProfilePublic() {
       const userId = currentUser.uid;
       const targetId = profile.uid;
 
-      // PERFIL PRIVAT → de moment només front-end: PENDENT
-      if (isPrivateProfile) {
-        if (followStatus === "none") {
-          // TODO: quan el backend tingui endpoint de sol·licitud, cridar-lo aquí
-          // await requestFollow(userId, targetId);
+      // Si no segueix, intentar seguir
+      if (followStatus === "none") {
+        await followUser(userId, targetId);
+        
+        // Actualitzar estat segons si el perfil és privat o públic
+        if (isPrivateProfile) {
+          // Perfil privat → estat pending
           setFollowStatus("pending");
-        } else if (followStatus === "following") {
-          // Si ja seguia i vol deixar de seguir en un perfil privat aprovat
-          await unfollowUser(userId, targetId);
-          setIsFollowing(false);
-          setFollowStatus("none");
-
+        } else {
+          // Perfil públic → estat following
+          setIsFollowing(true);
+          setFollowStatus("following");
           setProfile((prev) =>
             prev
-              ? {
-                  ...prev,
-                  llista_seguidors: (prev.llista_seguidors || []).filter(
-                    (uid) => uid !== userId
-                  ),
-                }
+              ? { ...prev, llista_seguidors: [...(prev.llista_seguidors || []), userId] }
               : prev
           );
         }
-        // Si està "pending", de moment no fem res (en el futur podria ser "cancel·lar sol·licitud")
-        return;
-      }
-
-      // PERFIL PÚBLIC → lògica actual de seguir / deixar de seguir
-      if (!isFollowing) {
-        await followUser(userId, targetId);
-        setIsFollowing(true);
-        setFollowStatus("following");
-
-        setProfile((prev) =>
-          prev
-            ? { ...prev, llista_seguidors: [...(prev.llista_seguidors || []), userId] }
-            : prev
-        );
-      } else {
+      } else if (followStatus === "following") {
+        // Si ja segueix, deixar de seguir
         await unfollowUser(userId, targetId);
         setIsFollowing(false);
         setFollowStatus("none");
+
         setProfile((prev) =>
           prev
-            ? { ...prev, llista_seguidors: (prev.llista_seguidors || []).filter((uid) => uid !== userId) }
+            ? {
+                ...prev,
+                llista_seguidors: (prev.llista_seguidors || []).filter(
+                  (uid) => uid !== userId
+                ),
+              }
             : prev
         );
+      } else if (followStatus === "pending") {
+        // Si la sol·licitud està pending, cancel·lar-la
+        await cancel_follow_request(userId, targetId);
+        setFollowStatus("none");
       }
     } catch (err) {
       console.error(t('profile_error_unfollowing'), err);
@@ -415,11 +417,11 @@ export default function UserProfilePublic() {
 
                 {currentUser && currentUser.uid !== profile.uid && !imBlocked && (
                   <button
-                    className={`follow-button ${isFollowing ? "following" : ""}`}
+                    className={buttonClass}
                     disabled={followLoading || isBlocked}
                     onClick={handleFollow}
                   >
-                    {isFollowing ? t('route_detail_following') : t('route_detail_follow')}
+                    {buttonLabel}
                   </button>
                 )}
               </div>

--- a/frontend/src/pages/UserProfilePublic.tsx
+++ b/frontend/src/pages/UserProfilePublic.tsx
@@ -332,11 +332,11 @@ export default function UserProfilePublic() {
   // Text i estil del botó segons estat
   const buttonLabel = (() => {
     if (isPrivate) {
-      if (followStatus === "pending") return "Pendent";
-      if (followStatus === "following") return "Seguint";
-      return "Seguir";
+      if (followStatus === "pending") return t('user_profile_pending');
+      if (followStatus === "following") return t('user_profile_following');
+      return t('user_profile_follow');
     }
-    return isFollowing ? "Seguint" : "Seguir";
+    return isFollowing ? t('user_profile_following') : t('user_profile_follow');
   })();
 
   const buttonClass = `follow-button ${

--- a/frontend/src/styles/RutaDetall.header-actions.css
+++ b/frontend/src/styles/RutaDetall.header-actions.css
@@ -204,6 +204,12 @@
   border-color: #2e7d32;
 }
 
+.follow-button.pending {
+  background-color: #9e9e9e;
+  color: white;
+  border-color: #9e9e9e;
+}
+
 .follow-button:disabled {
   opacity: 0.6;
   cursor: default;

--- a/frontend/src/styles/RutaDetalls.css
+++ b/frontend/src/styles/RutaDetalls.css
@@ -574,6 +574,13 @@
   border-color: #2e7d32;
 }
 
+/* Estat quan la sol·licitud està pending (perfil privat) */
+.follow-button.pending {
+  background-color: #9e9e9e !important;
+  color: white !important;
+  border-color: #9e9e9e;
+}
+
 .follow-button:disabled {
   opacity: 0.6;
   cursor: default;


### PR DESCRIPTION
Quan un perfil és privat, ara el botó de seguiment passa a estat "pendent" i no "seguint" a l'espera de que s'accepti una sol·licitud.

Classes modificades:
- frontend/src/pages/RutaDetall.tsx
- frontend/src/pages/UserProfilePublic.tsx
- frontend/src/styles/RutaDetall.header-actions.css
- frontend/src/styles/RutaDetalls.css
- frontend/src/i18n/ca.json
- frontend/src/i18n/en.json
- frontend/src/i18n/es.json