### PR TITLE
US-11.1: Tasca 2: Gestionar opcions de la sol·licitud

### DIFF
--- a/api/app/routers/users.py
+++ b/api/app/routers/users.py
@@ -212,14 +212,90 @@ async def cancel_follow_request(user_id: str, target_id: str):
     return {"message": "Sol·licitud de seguiment cancel·lada correctament"}
 
 
+@router.post("/accept_follow_request/{user_id}/{follower_id}")
+async def accept_follow_request(user_id: str, follower_id: str):
+    """
+    Accepta una sol·licitud de seguiment.
+    Afegeix follower_id a la llista de seguidors del user_id.
+    Afegeix user_id a la llista de seguits del follower_id.
+    Elimina les sol·licituds pendents.
+    """
+    user_ref = db.collection("users").document(user_id)
+    follower_ref = db.collection("users").document(follower_id)
+
+    user_doc = user_ref.get()
+    follower_doc = follower_ref.get()
+
+    if not user_doc.exists:
+        raise HTTPException(status_code=404, detail="L'usuari no existeix")
+    if not follower_doc.exists:
+        raise HTTPException(status_code=404, detail="L'usuari seguidor no existeix")
+
+    # Afegir follower a seguidors de user
+    user_ref.update({"llista_seguidors": firestore.ArrayUnion([follower_id])})
+    # Afegir user a seguits de follower
+    follower_ref.update({"llista_seguits": firestore.ArrayUnion([user_id])})
+
+    # Eliminar de les llistes de sol·licituds pendents
+    user_ref.update({"llista_solicitud_seguidors": firestore.ArrayRemove([follower_id])})
+    follower_ref.update({"llista_solicitud_seguits": firestore.ArrayRemove([user_id])})
+
+    return {"message": "Sol·licitud de seguiment acceptada correctament"}
+
+
+@router.post("/reject_follow_request/{user_id}/{follower_id}")
+async def reject_follow_request(user_id: str, follower_id: str):
+    """
+    Rebutja una sol·licitud de seguiment.
+    Simplement elimina la sol·licitud pendent sense afegir a seguidors.
+    """
+    user_ref = db.collection("users").document(user_id)
+    follower_ref = db.collection("users").document(follower_id)
+
+    user_doc = user_ref.get()
+    follower_doc = follower_ref.get()
+
+    if not user_doc.exists:
+        raise HTTPException(status_code=404, detail="L'usuari no existeix")
+    if not follower_doc.exists:
+        raise HTTPException(status_code=404, detail="L'usuari seguidor no existeix")
+
+    # Eliminar de les llistes de sol·licituds pendents
+    user_ref.update({"llista_solicitud_seguidors": firestore.ArrayRemove([follower_id])})
+    follower_ref.update({"llista_solicitud_seguits": firestore.ArrayRemove([user_id])})
+
+    return {"message": "Sol·licitud de seguiment rebutjada correctament"}
+
+
 @router.post("/follow/{user_id}/{target_id}")
 async def follow_user(user_id: str, target_id: str):
     """
     Afegeix el target_id a la llista 'llista_seguits' del user_id,
     i afegeix el user_id a la llista 'llista_seguidors' del target_id.
-    
-    Si el target té perfil privat, crea una sol·licitud de seguiment.
-    Si el target té perfil públic, segueix directament.
+    """
+    if user_id == target_id:
+        raise HTTPException(status_code=400, detail="No et pots seguir a tu mateix")
+
+    user_ref = db.collection("users").document(user_id)
+    target_ref = db.collection("users").document(target_id)
+
+    # Comprovació que l'usuari a seguir existeix
+    target_doc = target_ref.get()
+    if not target_doc.exists:
+        raise HTTPException(
+            status_code=404, detail="L'usuari que vols seguir no existeix"
+        )
+
+    user_ref.update({"llista_seguits": firestore.ArrayUnion([target_id])})
+    target_ref.update({"llista_seguidors": firestore.ArrayUnion([user_id])})
+    return {"message": "Usuari seguit correctament"}
+
+
+@router.post("/askToFollowUser/{user_id}/{target_id}")
+async def ask_to_follow_user(user_id: str, target_id: str):
+    """
+    Afegeix el target_id a la llista 'llista_solicitud_seguidors' del user_id,
+    i afegeix el user_id a la llista 'llista_solicitud_seguits' del target_id.
     """
     if user_id == target_id:
         raise HTTPException(status_code=400, detail="No et pots seguir a tu mateix")
@@ -238,16 +314,9 @@ async def follow_user(user_id: str, target_id: str):
     target_data = target_doc.to_dict()
     is_private = target_data.get("isPrivate", False)
 
-    if is_private:
-        # Si és privat, crear una sol·licitud de seguiment
-        target_ref.update({"llista_solicitud_seguidors": firestore.ArrayUnion([user_id])})
-        user_ref.update({"llista_solicitud_seguits": firestore.ArrayUnion([target_id])})
-        return {"message": "Sol·licitud de seguiment enviada correctament"}
-    else:
-        # Si és públic, seguir directament
-        user_ref.update({"llista_seguits": firestore.ArrayUnion([target_id])})
-        target_ref.update({"llista_seguidors": firestore.ArrayUnion([user_id])})
-        return {"message": "Usuari seguit correctament"}
+    target_ref.update({"llista_solicitud_seguidors": firestore.ArrayUnion([user_id])})
+    user_ref.update({"llista_solicitud_seguits": firestore.ArrayUnion([target_id])})
+    return {"message": "Sol·licitud de seguiment enviada correctament"}
 
 
 @router.post("/save/{user_id}/{trip_id}")

--- a/api/app/services/mongo_service.py
+++ b/api/app/services/mongo_service.py
@@ -249,6 +249,8 @@ def list_notifications(user_id: str, only_unread: bool = False):
             {
                 "id": str(n["_id"]),
                 "type": n["type"],
+                "fromUserId": n.get("fromUserId"),
+                "toUserId": n.get("toUserId"),
                 "fromUserName": extra.get("fromUserName", "Algú"),
                 "fromUserAvatar": extra.get("fromUserAvatar"),
                 "tripTitle": extra.get("tripTitle"),

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -69,15 +69,39 @@ export async function getAllUsers() {
   return apiGet("/users");
 }
 
+// Seguir un usuari
 export async function followUser(userId: string, targetId: string) {
   const res = await apiPost(`/users/follow/${userId}/${targetId}`, {});
+
+  try {
+    const userData = await getUserById(userId);
+
+    await createNotification({
+      fromUserId: userId,
+      toUserId: targetId,
+      type: "follow",
+      message: "ha començat a seguir-te",
+      extra: {
+        fromUserName: userData.nom_i_cognoms ?? userData.username ?? "",
+        fromUserAvatar: userData.url_foto_perfil ?? "",
+      },
+    });
+  } catch (e) {
+    console.warn("⚠️ No s'ha pogut crear la notificació de follow:", e);
+  }
+
+  return res;
+}
+
+// Enviar sol·licitud de seguiment
+export async function askToFollowUser(userId: string, targetId: string) {
+  const res = await apiPost(`/users/askToFollowUser/${userId}/${targetId}`, {});
 
   try {
     const userData = await getUserById(userId);
     const targetUserData = await getUserById(targetId);
 
     if (targetUserData.isPrivate) {
-      // Si l'usuari a seguir és privat, s'envia una sol·licitud de seguiment
       await createNotification({
         fromUserId: userId,
         toUserId: targetId,
@@ -89,26 +113,15 @@ export async function followUser(userId: string, targetId: string) {
           actionButton: true,
         },
       });
-    } else {
-      // Si l'usuari a seguir és públic, s'envia una notificación simple
-      await createNotification({
-        fromUserId: userId,
-        toUserId: targetId,
-        type: "follow",
-        message: "ha començat a seguir-te",
-        extra: {
-          fromUserName: userData.nom_i_cognoms ?? userData.username ?? "",
-          fromUserAvatar: userData.url_foto_perfil ?? "",
-        },
-      });
     }
   } catch (e) {
-    console.warn("⚠️ No s'ha pogut crear la notificació de follow:", e);
+    console.warn("⚠️ No s'ha pogut crear la sol·licitud de follow:", e);
   }
 
   return res;
 }
 
+// Deixar de seguir un usuari
 export async function unfollowUser(userId: string, targetId: string) {
   const res = await apiPost(`/users/unfollow/${userId}/${targetId}`, {});
 
@@ -135,6 +148,16 @@ export async function unfollowUser(userId: string, targetId: string) {
 // Eliminar sol·licitud de seguiment
 export async function cancel_follow_request(userId: string, targetId: string) {
   return apiPost(`/users/cancel_follow_request/${userId}/${targetId}`, {});
+}
+
+// Acceptar sol·licitud de seguiment
+export async function accept_follow_request(userId: string, targetId: string) {
+  return apiPost(`/users/accept_follow_request/${userId}/${targetId}`, {});
+}
+
+// Rebutjar sol·licitud de seguiment
+export async function reject_follow_request(userId: string, targetId: string) {
+  return apiPost(`/users/reject_follow_request/${userId}/${targetId}`, {});
 }
 
 // Guardar una ruta
@@ -193,13 +216,12 @@ export async function removePublication(userId: string, tripId: string) {
   return apiDelete(`/users/${userId}/publicacions/${tripId}`);
 }
 
-// (opcional) si ja no el fas servir, pots BORRAR aquesta funció
 export async function deleteTripAndPublication(userId: string, tripId: string) {
   await deleteTripById(tripId);
   await removePublication(userId, tripId);
 }
 
-// 🔻 NOVA: eliminar compte completament (backend: DELETE /users/delete/{user_id})
+// eliminar compte completament (backend: DELETE /users/delete/{user_id})
 export async function deleteAccount(userId: string) {
   return apiDelete(`/users/delete/${userId}`);
 }

--- a/frontend/src/api/notifier.ts
+++ b/frontend/src/api/notifier.ts
@@ -73,3 +73,18 @@ export async function createNotification(data: {
 export async function markNotificationAsRead(notificationId: string) {
   return apiPut(`/notifications/read/${notificationId}`);
 }
+
+export async function deleteNotification(notificationId: string) {
+  const user = getAuth().currentUser;
+  const token = user ? await user.getIdToken() : null;
+
+  const res = await fetch(`${API_URL}/notifications/${notificationId}`, {
+    method: "DELETE",
+    headers: {
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+  });
+
+  if (!res.ok) throw new Error(`API Error ${res.status}`);
+  return res.json();
+}

--- a/frontend/src/components/Mailbox.tsx
+++ b/frontend/src/components/Mailbox.tsx
@@ -1,11 +1,16 @@
 import { X, Mail, Bell, MessageCircle, Star } from "lucide-react";
 import "../styles/MailBox.css";
+import { accept_follow_request, reject_follow_request, followUser } from "../api/client";
+import { auth } from "../firebase";
+import { deleteNotification } from "../api/notifier";
 
 export type NotificationType = "follow" | "follow_request" | "comment" | "rating";
 
 export type Notification = {
   id: string;
   type: NotificationType;
+  fromUserId: string;
+  toUserId: string;
   fromUserName: string;
   fromUserAvatar?: string;
   tripTitle?: string;
@@ -18,7 +23,7 @@ type Props = {
   open: boolean;
   onClose: () => void;
   notifications?: Notification[];
-  onMarkRead?: (id: string) => void; // NUEVO
+  onMarkRead?: (id: string) => void;
 };
 
 function formatDate(dateStr: string) {
@@ -52,6 +57,48 @@ export default function Mailbox({ open, onClose, notifications, onMarkRead }: Pr
 
   const items = notifications || [];
   const unreadCount = items.filter((n) => !n.read).length;
+
+  const handleAccept = async (notification: Notification) => {
+  if (!auth.currentUser) return;
+
+  const currentUserId = auth.currentUser.uid;
+  const fromUserId = notification.fromUserId;
+
+  
+  try {
+    if (!fromUserId) {
+      alert("No es pot acceptar la sol·licitud: manca l'ID de l'usuari.");
+    } else {
+      await accept_follow_request(currentUserId, fromUserId); // acceptar la sol·licitud
+      await followUser(fromUserId, currentUserId);  // fer que ens segueixi l'usuari
+    }
+  } catch (err) {
+    console.error(err);
+    alert("Error al acceptar la sol·licitud de seguiment.");
+  } finally {
+    await deleteNotification(notification.id);  // eliminar la notificació
+  }
+};
+
+const handleReject = async (notification: Notification) => {
+  if (!auth.currentUser) return;
+
+  const currentUserId = auth.currentUser.uid;
+  const fromUserId = notification.fromUserId;
+
+  try {
+    if (!fromUserId) {
+      alert("No es pot rebutjar la sol·licitud: manca l'ID de l'usuari.");
+    } else {
+      await reject_follow_request(currentUserId, fromUserId); // rebutjar la sol·licitud
+    }
+  } catch (err) {
+    console.error(err);
+    alert("Error al rebuthar la sol·licitud de seguiment.");
+  } finally {
+    await deleteNotification(notification.id);  // eliminar la notificació
+  }
+};
 
   return (
     <div
@@ -112,8 +159,8 @@ export default function Mailbox({ open, onClose, notifications, onMarkRead }: Pr
 
                   {n.type === "follow_request" && !n.read && (
                     <div className="follow-request-actions">
-                      <button onClick={() => acceptFollowRequest(n.id)}>Acceptar</button>
-                      <button onClick={() => rejectFollowRequest(n.id)}>Rebutjar</button>
+                      <button onClick={() => handleAccept(n)}>Acceptar</button>
+                      <button onClick={() => handleReject(n)}>Rebutjar</button>
                     </div>
                   )}
 

--- a/frontend/src/pages/UserProfilePublic.tsx
+++ b/frontend/src/pages/UserProfilePublic.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { onAuthStateChanged, type User as FirebaseUser, signOut } from "firebase/auth";
 import { useNavigate, useParams } from "react-router-dom";
 import { auth } from "../firebase";
-import { getUserById, followUser, unfollowUser, blockUser, unblockUser, cancel_follow_request } from "../api/client";
+import { getUserById, followUser, unfollowUser, blockUser, unblockUser, cancel_follow_request, askToFollowUser } from "../api/client";
 import { getAllTrips, type Trip } from "../api/trips";
 import "../styles/UserProfile.css";
 import { ImageOff, UserX } from "lucide-react";
@@ -30,6 +30,8 @@ export type BackendUser = {
   isPrivate?: boolean;
   llista_bloquejats?: string[];
   llista_bloquejadors?: string[];
+  llista_solicitud_seguidors?: string[];
+  llista_solicitud_seguits?: string[];
 };
 
 type FollowStatus = "none" | "pending" | "following";
@@ -90,6 +92,8 @@ export default function UserProfilePublic() {
         backendUser.publicacions = backendUser.publicacions || [];
         backendUser.llista_bloquejats = backendUser.llista_bloquejats || [];
         backendUser.llista_bloquejadors = backendUser.llista_bloquejadors || [];
+        backendUser.llista_solicitud_seguidors = backendUser.llista_solicitud_seguidors || [];
+        backendUser.llista_solicitud_seguits = backendUser.llista_solicitud_seguits || [];
 
         setProfile(backendUser as BackendUser);
 
@@ -110,7 +114,7 @@ export default function UserProfilePublic() {
     fetchProfile();
   }, [id, t]);
 
-  // Saber si el currentUser segueix aquest perfil
+  // Saber si el currentUser segueix aquest perfil o ha solicitat seguir-lo
   useEffect(() => {
     if (!currentUser || !profile) {
       setIsFollowing(false);
@@ -119,10 +123,18 @@ export default function UserProfilePublic() {
     }
 
     const followers = profile.llista_seguidors || [];
-    const alreadyFollowing = followers.includes(currentUser.uid);
+    const pendingRequests = profile.llista_solicitud_seguidors || [];
 
-    setIsFollowing(alreadyFollowing);
-    setFollowStatus(alreadyFollowing ? "following" : "none");
+    if (followers.includes(currentUser.uid)) {
+      setIsFollowing(true);
+      setFollowStatus("following");
+    } else if (pendingRequests.includes(currentUser.uid)) {
+      setIsFollowing(false);
+      setFollowStatus("pending");
+    } else {
+      setIsFollowing(false);
+      setFollowStatus("none");
+    }
   }, [currentUser, profile]);
 
   // Saber si l'hem bloquejat (Staging)
@@ -165,15 +177,15 @@ export default function UserProfilePublic() {
 
       // Si no segueix, intentar seguir
       if (followStatus === "none") {
-        await followUser(userId, targetId);
         
         // Actualitzar estat segons si el perfil és privat o públic
         if (isPrivateProfile) {
           // Perfil privat → estat pending
+          await askToFollowUser(userId, targetId);
           setFollowStatus("pending");
         } else {
           // Perfil públic → estat following
-          setIsFollowing(true);
+          await followUser(userId, targetId);
           setFollowStatus("following");
           setProfile((prev) =>
             prev


### PR DESCRIPTION
Quan un usuari rep una sol·licitud de seguiment, ara pot acceptar-la o rebutjar-la.
- En cas d'acceptar-la, l'usuari que l'ha enviat el comença a seguir.
- En cas de rebutjar-la, no passa res.

També he separat endpoint followUser i askToFollowUser per poder gestionar millor el tipus de notificació que s'envia i poder utilitzar followUser per facilitar el fet de que et segueixi un usuari quan acceptes la seva la sol·licitud encara que el perfil sigui privat. He actualitzat la lògica del handler de seguiment UserProfilePublic.tsx en conseqüència.

Classes modificades:
- api/app/routers/users.py
- api/app/services/mongo_service.py 
- frontend/src/api/client.ts
- frontend/src/api/notifier.ts
- frontend/src/components/Mailbox.tsx
- frontend/src/pages/UserProfilePublic.tsx