### PR TITLE
US-11.1: Tasca 3: Acceptar automàticament en fer perfil públic

### DIFF
--- a/api/app/routers/notifications.py
+++ b/api/app/routers/notifications.py
@@ -4,6 +4,7 @@ from app.services.mongo_service import (
     create_notification,
     list_notifications,
     mark_notification_as_read,
+    delete_notification,
 )
 
 router = APIRouter(prefix="/notifications", tags=["Notifications"])
@@ -32,3 +33,11 @@ def mark_as_read(notification_id: str):
     if not ok:
         raise HTTPException(status_code=404, detail="Notification not found")
     return {"status": "ok"}
+
+
+@router.delete("/{notification_id}")
+def delete_notif(notification_id: str):
+    ok = delete_notification(notification_id)
+    if not ok:
+        raise HTTPException(status_code=404, detail="Notification not found")
+    return {"status": "deleted"}

--- a/api/app/services/mongo_service.py
+++ b/api/app/services/mongo_service.py
@@ -271,3 +271,14 @@ def mark_notification_as_read(notification_id: str):
         return res.modified_count == 1
     except Exception:
         return False
+
+
+def delete_notification(notification_id: str):
+    """Elimina una notificació per ID"""
+    try:
+        res = notifications_collection.delete_one(
+            {"_id": ObjectId(notification_id)}
+        )
+        return res.deleted_count == 1
+    except Exception:
+        return False

--- a/frontend/src/components/Mailbox.tsx
+++ b/frontend/src/components/Mailbox.tsx
@@ -70,7 +70,6 @@ export default function Mailbox({ open, onClose, notifications, onMarkRead }: Pr
       alert("No es pot acceptar la sol·licitud: manca l'ID de l'usuari.");
     } else {
       await accept_follow_request(currentUserId, fromUserId); // acceptar la sol·licitud
-      await followUser(fromUserId, currentUserId);  // fer que ens segueixi l'usuari
     }
   } catch (err) {
     console.error(err);

--- a/frontend/src/components/UserSettings.tsx
+++ b/frontend/src/components/UserSettings.tsx
@@ -3,7 +3,8 @@ import "../styles/UserSettings.css";
 import { X } from "lucide-react";
 import { auth } from "../firebase";
 import { signOut } from "firebase/auth";
-import { deleteAccount } from "../api/client";
+import { deleteAccount, accept_follow_request } from "../api/client";
+import { getNotifications, deleteNotification } from "../api/notifier";
 import i18n from "../i18n/i18n";
 import { useTranslation } from 'react-i18next';
 import type { BackendUser } from "../pages/UserProfile";
@@ -89,6 +90,42 @@ export default function UserSettings({ open, profile, onClose, onSavePrivacy }: 
         ...profile,
         isPrivate: newPrivacy,
       };
+
+      // Si canvia a públic (newPrivacy === false)
+      if (!newPrivacy) {
+        try {
+          // 1. Acceptar totes les sol·licituds pendents
+          if (profile.llista_solicitud_seguidors && profile.llista_solicitud_seguidors.length > 0) {
+            const pendingRequests = profile.llista_solicitud_seguidors;
+            
+            for (const fromUserId of pendingRequests) {
+              await accept_follow_request(profile.uid, fromUserId);
+            }
+            console.log(`✅ S'han acceptat ${pendingRequests.length} sol·licituds pendents`);
+          }
+
+          // 2. Eliminar TOTES les notificacions de sol·licitud de seguiment (independentment del seu origen)
+          try {
+            const notifications = await getNotifications(profile.uid, false);
+            const followRequestNotifs = notifications.filter(
+              (n: any) => n.type === "follow_request"
+            );
+
+            for (const notif of followRequestNotifs) {
+              await deleteNotification(notif.id);
+            }
+
+            if (followRequestNotifs.length > 0) {
+              console.log(`🗑️ S'han eliminat ${followRequestNotifs.length} notificacions de sol·licitud de seguiment`);
+            }
+          } catch (err) {
+            console.error("⚠️ Error eliminant notificacions:", err);
+          }
+        } catch (err) {
+          console.error("⚠️ Error acceptant sol·licituds pendents:", err);
+          // No aturem l'execució, ja que el perfil s'ha canviat correctament
+        }
+      }
 
       if (onSavePrivacy) onSavePrivacy(updatedProfile);
     } catch (e: any) {

--- a/frontend/src/pages/UserProfile.tsx
+++ b/frontend/src/pages/UserProfile.tsx
@@ -28,6 +28,10 @@ export type BackendUser = {
   seguits?: number;
   llista_seguidors?: string[];
   llista_seguits?: string[];
+  llista_solicitud_seguidors?: string[];
+  llista_solicitud_seguits?: string[];
+  llista_bloquejats?: string[];
+  llista_bloquejadors?: string[];
   publicacions?: string[];
   guardades?: string[];
   url_foto_perfil?: string;
@@ -89,6 +93,8 @@ export default function UserProfile() {
         const backendUser = await getUserById(fbUser.uid);
         backendUser.llista_seguidors = backendUser.llista_seguidors || [];
         backendUser.llista_seguits = backendUser.llista_seguits || [];
+        backendUser.llista_solicitud_seguidors = backendUser.llista_solicitud_seguidors || [];
+        backendUser.llista_solicitud_seguits = backendUser.llista_solicitud_seguits || [];
         backendUser.publicacions = backendUser.publicacions || [];
         backendUser.guardades = backendUser.guardades || [];
         backendUser.llista_bloquejats = backendUser.llista_bloquejats || [];


### PR DESCRIPTION
Quan un usuari fa públic el seu perfil usant la configuració, si tenia sol·licituds de seguiment pendents de gestionar aquestes s'accepten automàticament i s'eliminen de la seva llista de notificacions.

Classes modificades:
- api/app/routers/notifications.py
- api/app/services/mongo_service.py
- frontend/src/components/Mailbox.tsx
- frontend/src/components/UserSettings.tsx
- frontend/src/pages/UserProfile.tsx