### PR TITLE
US-11.1: Tasca 4: Actualitzar dades frontend perfil

### DIFF
--- a/api/app/routers/users.py
+++ b/api/app/routers/users.py
@@ -13,6 +13,7 @@ from firebase_admin import auth
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from app.services.mongo_service import (
     delete_trip,
+    create_notification,
 )
 
 security = HTTPBearer()
@@ -231,14 +232,30 @@ async def accept_follow_request(user_id: str, follower_id: str):
     if not follower_doc.exists:
         raise HTTPException(status_code=404, detail="L'usuari seguidor no existeix")
 
-    # Afegir follower a seguidors de user
-    user_ref.update({"llista_seguidors": firestore.ArrayUnion([follower_id])})
-    # Afegir user a seguits de follower
-    follower_ref.update({"llista_seguits": firestore.ArrayUnion([user_id])})
+    # Reutilitzar la lògica de follow per assegurar consistència
+    await follow_user(follower_id, user_id)
 
     # Eliminar de les llistes de sol·licituds pendents
     user_ref.update({"llista_solicitud_seguidors": firestore.ArrayRemove([follower_id])})
     follower_ref.update({"llista_solicitud_seguits": firestore.ArrayRemove([user_id])})
+
+    # Crear notificació de nou seguidor (mateix format que client.ts)
+    try:
+        follower_data = follower_doc.to_dict() or {}
+        extra = {
+            "fromUserName": follower_data.get("nom_i_cognoms") or follower_data.get("username") or "",
+            "fromUserAvatar": follower_data.get("url_foto_perfil", ""),
+        }
+
+        create_notification(
+            from_user_id=follower_id,
+            to_user_id=user_id,
+            type="follow",
+            message="ha començat a seguir-te",
+            extra=extra,
+        )
+    except Exception as e:
+        print(f"[WARN] No s'ha pogut crear la notificació de follow en acceptar la sol·licitud: {e}")
 
     return {"message": "Sol·licitud de seguiment acceptada correctament"}
 

--- a/frontend/src/components/Mailbox.tsx
+++ b/frontend/src/components/Mailbox.tsx
@@ -1,6 +1,6 @@
 import { X, Mail, Bell, MessageCircle, Star } from "lucide-react";
 import "../styles/MailBox.css";
-import { accept_follow_request, reject_follow_request, followUser } from "../api/client";
+import { accept_follow_request, reject_follow_request } from "../api/client";
 import { auth } from "../firebase";
 import { deleteNotification } from "../api/notifier";
 
@@ -24,6 +24,8 @@ type Props = {
   onClose: () => void;
   notifications?: Notification[];
   onMarkRead?: (id: string) => void;
+  onAfterAccept?: (id: string) => Promise<void> | void;
+  onAfterReject?: (id: string) => Promise<void> | void;
 };
 
 function formatDate(dateStr: string) {
@@ -52,32 +54,38 @@ function getIcon(type: NotificationType) {
   }
 }
 
-export default function Mailbox({ open, onClose, notifications, onMarkRead }: Props) {
+export default function Mailbox({ open, onClose, notifications, onMarkRead, onAfterAccept, onAfterReject }: Props) {
   if (!open) return null;
 
   const items = notifications || [];
   const unreadCount = items.filter((n) => !n.read).length;
 
   const handleAccept = async (notification: Notification) => {
-  if (!auth.currentUser) return;
+    if (!auth.currentUser) return;
 
-  const currentUserId = auth.currentUser.uid;
-  const fromUserId = notification.fromUserId;
+    const currentUserId = auth.currentUser.uid;
+    const fromUserId = notification.fromUserId;
 
-  
-  try {
-    if (!fromUserId) {
-      alert("No es pot acceptar la sol·licitud: manca l'ID de l'usuari.");
-    } else {
-      await accept_follow_request(currentUserId, fromUserId); // acceptar la sol·licitud
+    try {
+      if (!fromUserId) {
+        alert("No es pot acceptar la sol·licitud: manca l'ID de l'usuari.");
+      } else {
+        await accept_follow_request(currentUserId, fromUserId);
+      }
+    } catch (err) {
+      console.error(err);
+      alert("Error al acceptar la sol·licitud de seguiment.");
+    } finally {
+      await deleteNotification(notification.id);
+      if (onAfterAccept) {
+        try {
+          await onAfterAccept(notification.id);
+        } catch (cbErr) {
+          console.error("Error després d'acceptar:", cbErr);
+        }
+      }
     }
-  } catch (err) {
-    console.error(err);
-    alert("Error al acceptar la sol·licitud de seguiment.");
-  } finally {
-    await deleteNotification(notification.id);  // eliminar la notificació
-  }
-};
+  };
 
 const handleReject = async (notification: Notification) => {
   if (!auth.currentUser) return;
@@ -96,6 +104,13 @@ const handleReject = async (notification: Notification) => {
     alert("Error al rebuthar la sol·licitud de seguiment.");
   } finally {
     await deleteNotification(notification.id);  // eliminar la notificació
+    if (onAfterReject) {
+      try {
+        await onAfterReject(notification.id);
+      } catch (cbErr) {
+        console.error("Error després de rebutjar:", cbErr);
+      }
+    }
   }
 };
 

--- a/frontend/src/components/UserSettings.tsx
+++ b/frontend/src/components/UserSettings.tsx
@@ -3,7 +3,7 @@ import "../styles/UserSettings.css";
 import { X } from "lucide-react";
 import { auth } from "../firebase";
 import { signOut } from "firebase/auth";
-import { deleteAccount, accept_follow_request } from "../api/client";
+import { deleteAccount, accept_follow_request, getUserById } from "../api/client";
 import { getNotifications, deleteNotification } from "../api/notifier";
 import i18n from "../i18n/i18n";
 import { useTranslation } from 'react-i18next';
@@ -83,10 +83,9 @@ export default function UserSettings({ open, profile, onClose, onSavePrivacy }: 
         throw new Error(err.detail || t('profile_error_updating'));
       }
 
-      // Actualitzem l'estat local
       setIsPrivate(newPrivacy);
 
-      const updatedProfile: BackendUser = {
+      let updatedProfile: BackendUser = {
         ...profile,
         isPrivate: newPrivacy,
       };
@@ -125,6 +124,24 @@ export default function UserSettings({ open, profile, onClose, onSavePrivacy }: 
           console.error("⚠️ Error acceptant sol·licituds pendents:", err);
           // No aturem l'execució, ja que el perfil s'ha canviat correctament
         }
+      }
+
+      try {
+        const refreshedProfile = await getUserById(profile.uid);
+        updatedProfile = {
+          ...refreshedProfile,
+          llista_seguidors: refreshedProfile.llista_seguidors || [],
+          llista_seguits: refreshedProfile.llista_seguits || [],
+          llista_solicitud_seguidors: refreshedProfile.llista_solicitud_seguidors || [],
+          llista_solicitud_seguits: refreshedProfile.llista_solicitud_seguits || [],
+          publicacions: refreshedProfile.publicacions || [],
+          guardades: refreshedProfile.guardades || [],
+          llista_bloquejats: refreshedProfile.llista_bloquejats || [],
+          llista_bloquejadors: refreshedProfile.llista_bloquejadors || [],
+        } as BackendUser;
+        setIsPrivate(updatedProfile.isPrivate || false);
+      } catch (err) {
+        console.error("⚠️ Error refrescant el perfil després del canvi de privacitat:", err);
       }
 
       if (onSavePrivacy) onSavePrivacy(updatedProfile);

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -7,27 +7,27 @@ export default function useNotifications() {
   const [notifications, setNotifications] = useState<Notification[]>([]);
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    async function fetchData() {
-      const user = getAuth().currentUser;
+  const fetchNotifications = async () => {
+    const user = getAuth().currentUser;
 
-      if (!user) {
-        setNotifications([]);
-        setLoading(false);
-        return;
-      }
-
-      try {
-        const data = await getNotifications(user.uid);
-        setNotifications(data);
-      } catch (err) {
-        console.error("Error carregant notificacions:", err);
-      } finally {
-        setLoading(false);
-      }
+    if (!user) {
+      setNotifications([]);
+      setLoading(false);
+      return;
     }
 
-    fetchData();
+    try {
+      const data = await getNotifications(user.uid);
+      setNotifications(data);
+    } catch (err) {
+      console.error("Error carregant notificacions:", err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchNotifications();
   }, []);
 
   const markRead = async (id: string) => {
@@ -41,5 +41,13 @@ export default function useNotifications() {
     }
   };
 
-  return { notifications, loading, markRead };
+  const refreshNotifications = async () => {
+    await fetchNotifications();
+  };
+
+  const removeLocal = (id: string) => {
+    setNotifications((prev) => prev.filter((n) => n.id !== id));
+  };
+
+  return { notifications, loading, markRead, refreshNotifications, removeLocal };
 }

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -1,23 +1,24 @@
 import { useEffect, useState } from "react";
 import { getNotifications, markNotificationAsRead } from "../api/notifier";
-import { getAuth } from "firebase/auth";
+import { getAuth, onAuthStateChanged } from "firebase/auth";
 import type { Notification } from "../components/Mailbox";
 
 export default function useNotifications() {
   const [notifications, setNotifications] = useState<Notification[]>([]);
   const [loading, setLoading] = useState(true);
+  const auth = getAuth();
 
-  const fetchNotifications = async () => {
-    const user = getAuth().currentUser;
+  const fetchNotifications = async (userId?: string) => {
+    const uid = userId || auth.currentUser?.uid;
 
-    if (!user) {
+    if (!uid) {
       setNotifications([]);
       setLoading(false);
       return;
     }
 
     try {
-      const data = await getNotifications(user.uid);
+      const data = await getNotifications(uid);
       setNotifications(data);
     } catch (err) {
       console.error("Error carregant notificacions:", err);
@@ -27,8 +28,19 @@ export default function useNotifications() {
   };
 
   useEffect(() => {
-    fetchNotifications();
-  }, []);
+    const unsubscribe = onAuthStateChanged(auth, (user) => {
+      if (!user) {
+        setNotifications([]);
+        setLoading(false);
+        return;
+      }
+
+      setLoading(true);
+      fetchNotifications(user.uid);
+    });
+
+    return () => unsubscribe();
+  }, [auth]);
 
   const markRead = async (id: string) => {
     try {
@@ -42,6 +54,7 @@ export default function useNotifications() {
   };
 
   const refreshNotifications = async () => {
+    setLoading(true);
     await fetchNotifications();
   };
 

--- a/frontend/src/pages/UserProfile.tsx
+++ b/frontend/src/pages/UserProfile.tsx
@@ -70,10 +70,34 @@ export default function UserProfile() {
   const [tripToDelete, setTripToDelete] = useState<string | null>(null);
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [mailboxOpen, setMailboxOpen] = useState(false);
-  const { notifications, loading: notifLoading, markRead } = useNotifications();
+  const {
+    notifications,
+    markRead,
+    refreshNotifications,
+    removeLocal,
+  } = useNotifications();
 
 
   const navigate = useNavigate();
+
+  const refreshProfile = async () => {
+    if (!currentUser) return;
+    try {
+      const updatedProfile = await getUserById(currentUser.uid);
+      updatedProfile.llista_seguidors = updatedProfile.llista_seguidors || [];
+      updatedProfile.llista_seguits = updatedProfile.llista_seguits || [];
+      updatedProfile.llista_solicitud_seguidors = updatedProfile.llista_solicitud_seguidors || [];
+      updatedProfile.llista_solicitud_seguits = updatedProfile.llista_solicitud_seguits || [];
+      updatedProfile.publicacions = updatedProfile.publicacions || [];
+      updatedProfile.guardades = updatedProfile.guardades || [];
+      updatedProfile.llista_bloquejats = updatedProfile.llista_bloquejats || [];
+      updatedProfile.llista_bloquejadors = updatedProfile.llista_bloquejadors || [];
+
+      setProfile(updatedProfile as BackendUser);
+    } catch (err) {
+      console.error("Error refrescant el perfil", err);
+    }
+  };
 
   // ---------------------------
   // Carregar usuari i trips
@@ -162,20 +186,20 @@ export default function UserProfile() {
   };
 
   const toGridItems = (trips: Trip[]): GridItem[] =>
-    trips.map((t) => ({
-      id: String(t._id),
-      title: t.title || t('general_no_title'),
+    trips.map((trip) => ({
+      id: String(trip._id),
+      title: trip.title || t('general_no_title'),
       img:
-        t.coverImage ||
-        (t.gallery && t.gallery[0]) ||
+        trip.coverImage ||
+        (trip.gallery && trip.gallery[0]) ||
         "https://placehold.co/600x400?text=Ruta+Sense+Imatge",
-      user: t.author?.name || t('general_anonymous'),
-      rating: typeof t.avgRating === "number" ? t.avgRating : 0,
-      temps: t.duration || "—",
-      dificultat: t.difficulty || "—",
-      authorPic: t.author?.profilePic || "",
-      city: t.city || "",
-      country: t.country || "",
+      user: trip.author?.name || t('general_anonymous'),
+      rating: typeof trip.avgRating === "number" ? trip.avgRating : 0,
+      temps: trip.duration || "—",
+      dificultat: trip.difficulty || "—",
+      authorPic: trip.author?.profilePic || "",
+      city: trip.city || "",
+      country: trip.country || "",
     }));
 
   const askDeleteTrip = (tripId: string) => {
@@ -249,6 +273,17 @@ export default function UserProfile() {
   
   const openMailbox = () => {
     setMailboxOpen(true);
+  };
+
+  const handleAfterAcceptNotification = async (notificationId: string) => {
+    removeLocal(notificationId);
+    await refreshNotifications();
+    await refreshProfile();
+  };
+
+  const handleAfterRejectNotification = async (notificationId: string) => {
+    removeLocal(notificationId);
+    await refreshNotifications();
   };
 
 
@@ -484,6 +519,8 @@ export default function UserProfile() {
             onClose={() => setMailboxOpen(false)}
             notifications={notifications}
             onMarkRead={markRead}
+            onAfterAccept={handleAfterAcceptNotification}
+            onAfterReject={handleAfterRejectNotification}
           />
 
 


### PR DESCRIPTION
Quan s'accepta una sol·licitud de seguiment, s'ha d'actualitzar la quantitat de seguidors mostrada al perfil.

Quan es canvia el perfil a públic i s'accepten les sol·licituds automàticament, s'ha d'actualitzar la bústia de notificacions.

Arreglat error en que al reiniciar la pàgina la bústia de notificacions apareixia buida.

Classes modificades:
- api/app/routers/users.py
- frontend/src/components/Mailbox.tsx
- frontend/src/components/UserSettings.tsx
- frontend/src/hooks/useNotifications.ts
- frontend/src/pages/UserProfile.tsx