### PR TITLE
US-04.1.1: Privacitat i US-11.1: Sol·licitud de seguiment

### DIFF
--- a/api/app/routers/notifications.py
+++ b/api/app/routers/notifications.py
@@ -4,6 +4,7 @@ from app.services.mongo_service import (
     create_notification,
     list_notifications,
     mark_notification_as_read,
+    delete_notification,
 )
 
 router = APIRouter(prefix="/notifications", tags=["Notifications"])
@@ -32,3 +33,11 @@ def mark_as_read(notification_id: str):
     if not ok:
         raise HTTPException(status_code=404, detail="Notification not found")
     return {"status": "ok"}
+
+
+@router.delete("/{notification_id}")
+def delete_notif(notification_id: str):
+    ok = delete_notification(notification_id)
+    if not ok:
+        raise HTTPException(status_code=404, detail="Notification not found")
+    return {"status": "deleted"}

--- a/api/app/routers/users.py
+++ b/api/app/routers/users.py
@@ -13,7 +13,7 @@ from firebase_admin import auth
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from app.services.mongo_service import (
     delete_trip,
-)  # 👈 AFEGIT: funció que esborra la trip a Mongo
+)
 
 security = HTTPBearer()
 
@@ -24,7 +24,7 @@ router = APIRouter(prefix="/users", tags=["Users"])
 async def register_user(data: dict, user=Depends(verify_token)):
     """
     Desa un nou usuari al Firestore després de registre al Firebase Auth.
-    El frontend envia fullname, username, mail, i el backend completa els defaults.
+    El frontend envia fullname, username, mail i isPrivate, i el backend completa els defaults.
     """
     uid = user.get("uid")
     if not uid:
@@ -42,9 +42,12 @@ async def register_user(data: dict, user=Depends(verify_token)):
         "guardades": data.get("guardades", []),
         "llista_seguidors": data.get("lista_seguidores", []),
         "llista_seguits": data.get("lista_seguidos", []),
+        "llista_solicitud_seguidors": data.get("llista_solicitud_seguidor", []),
+        "llista_solicitud_seguits": data.get("llista_solicitud_seguits", []),
         "url_foto_perfil": data.get("url_foto_perfil", ""),
         "url_foto_panell": data.get("url_foto_panell", ""),
         "premium": data.get("premium", False),
+        "isPrivate": data.get("isPrivate", False),
         "llista_bloquejats": data.get("llista_bloquejats", []),
         "llista_bloquejadors": data.get("llista_bloquejadors", []),
     }
@@ -95,6 +98,7 @@ class UserEditIn(BaseModel):
     username: Optional[str] = None
     url_foto_perfil: Optional[str] = None
     url_foto_panell: Optional[str] = None
+    isPrivate: Optional[bool] = None
 
 
 # (PATCH = modificació parcial)
@@ -174,11 +178,48 @@ async def unfollow_user(user_id: str, target_id: str):
     return {"message": "Has deixat de seguir l'usuari correctament"}
 
 
+@router.post("/cancel_follow_request/{user_id}/{target_id}")
+async def cancel_follow_request(user_id: str, target_id: str):
+    """
+    Cancel·la una sol·licitud de seguiment pendent.
+    Elimina user_id de llista_solicitud_seguidors del target_id.
+    Elimina target_id de llista_solicitud_seguits del user_id.
+    """
+    user_ref = db.collection("users").document(user_id)
+    target_ref = db.collection("users").document(target_id)
+
+    user_doc = user_ref.get()
+    target_doc = target_ref.get()
+
+    # Comprovem que l'usuari existeix
+    if not user_doc.exists:
+        raise HTTPException(
+            status_code=404, detail="L'usuari que intenta cancel·lar la sol·licitud no existeix"
+        )
+
+    # Comprovem que l'usuari target existeix
+    if not target_doc.exists:
+        raise HTTPException(
+            status_code=404, detail="L'usuari target no existeix"
+        )
+
+    # Eliminar de la llista de sol·licituds enviades
+    user_ref.update({"llista_solicitud_seguits": firestore.ArrayRemove([target_id])})
+
+    # Eliminar de la llista de sol·licituds rebudes
+    target_ref.update({"llista_solicitud_seguidors": firestore.ArrayRemove([user_id])})
+
+    return {"message": "Sol·licitud de seguiment cancel·lada correctament"}
+
+
 @router.post("/follow/{user_id}/{target_id}")
 async def follow_user(user_id: str, target_id: str):
     """
     Afegeix el target_id a la llista 'llista_seguits' del user_id,
     i afegeix el user_id a la llista 'llista_seguidors' del target_id.
+    
+    Si el target té perfil privat, crea una sol·licitud de seguiment.
+    Si el target té perfil públic, segueix directament.
     """
     if user_id == target_id:
         raise HTTPException(status_code=400, detail="No et pots seguir a tu mateix")
@@ -187,18 +228,26 @@ async def follow_user(user_id: str, target_id: str):
     target_ref = db.collection("users").document(target_id)
 
     # Comprovació que l'usuari a seguir existeix
-    if not target_ref.get().exists:
+    target_doc = target_ref.get()
+    if not target_doc.exists:
         raise HTTPException(
             status_code=404, detail="L'usuari que vols seguir no existeix"
         )
 
-    # Afegir a la llista de seguits
-    user_ref.update({"llista_seguits": firestore.ArrayUnion([target_id])})
+    # Verificar si el target té perfil privat
+    target_data = target_doc.to_dict()
+    is_private = target_data.get("isPrivate", False)
 
-    # Afegir a la llista de seguidors
-    target_ref.update({"llista_seguidors": firestore.ArrayUnion([user_id])})
-
-    return {"message": "Usuari seguit correctament"}
+    if is_private:
+        # Si és privat, crear una sol·licitud de seguiment
+        target_ref.update({"llista_solicitud_seguidors": firestore.ArrayUnion([user_id])})
+        user_ref.update({"llista_solicitud_seguits": firestore.ArrayUnion([target_id])})
+        return {"message": "Sol·licitud de seguiment enviada correctament"}
+    else:
+        # Si és públic, seguir directament
+        user_ref.update({"llista_seguits": firestore.ArrayUnion([target_id])})
+        target_ref.update({"llista_seguidors": firestore.ArrayUnion([user_id])})
+        return {"message": "Usuari seguit correctament"}
 
 
 @router.post("/save/{user_id}/{trip_id}")
@@ -275,9 +324,7 @@ async def unblock_user(user_id: str, target_id: str):
     i elimina el user_id de la llista 'llista_bloquejadors' del target_id.
     """
     if user_id == target_id:
-        raise HTTPException(
-            status_code=400, detail="No pots desbloquejar-te a tu mateix"
-        )
+        raise HTTPException(status_code=400, detail="No pots desbloquejar-te a tu mateix")
 
     user_ref = db.collection("users").document(user_id)
     target_ref = db.collection("users").document(target_id)
@@ -339,6 +386,39 @@ async def add_publicacio(user_id: str, trip_id: str, user=Depends(verify_token))
         "publicacions": list(publicacions),
     }
 
+@router.post("/removefollower/{user_id}/{target_id}")
+async def remove_follower(user_id: str, target_id: str):
+    """
+    Elimina el target_id de la llista de seguidors de user_id.
+    A més, elimina user_id de la llista de seguits del target_id
+    per mantenir la coherència.
+    """
+
+    user_ref = db.collection("users").document(user_id)
+    target_ref = db.collection("users").document(target_id)
+
+    user_doc = user_ref.get()
+    target_doc = target_ref.get()
+
+    if not user_doc.exists:
+        raise HTTPException(
+            status_code=404,
+            detail="L'usuari que rep el seguidor no existeix"
+        )
+
+    if not target_doc.exists:
+        raise HTTPException(
+            status_code=404,
+            detail="L'usuari que vols eliminar de seguidors no existeix"
+        )
+
+    # Eliminar target_id de la llista de seguidors
+    user_ref.update({"llista_seguidors": firestore.ArrayRemove([target_id])})
+
+    # Eliminar user_id de la llista de seguits del target
+    target_ref.update({"llista_seguits": firestore.ArrayRemove([user_id])})
+
+    return {"message": "Seguidor eliminat correctament"}
 
 @router.post("/removefollower/{user_id}/{target_id}")
 async def remove_follower(user_id: str, target_id: str):

--- a/api/app/routers/users.py
+++ b/api/app/routers/users.py
@@ -257,6 +257,24 @@ async def accept_follow_request(user_id: str, follower_id: str):
     except Exception as e:
         print(f"[WARN] No s'ha pogut crear la notificació de follow en acceptar la sol·licitud: {e}")
 
+    # Crear notificació al sol·licitant informant que se li ha acceptat la sol·licitud
+    try:
+        user_data = user_doc.to_dict() or {}
+        extra_accepted = {
+            "fromUserName": user_data.get("nom_i_cognoms") or user_data.get("username") or "",
+            "fromUserAvatar": user_data.get("url_foto_perfil", ""),
+        }
+
+        create_notification(
+            from_user_id=user_id,
+            to_user_id=follower_id,
+            type="follow",
+            message="ha acceptat la teva sol·licitud de seguiment",
+            extra=extra_accepted,
+        )
+    except Exception as e:
+        print(f"[WARN] No s'ha pogut crear la notificació d'acceptació al sol·licitant: {e}")
+
     return {"message": "Sol·licitud de seguiment acceptada correctament"}
 
 

--- a/api/app/routers/users.py
+++ b/api/app/routers/users.py
@@ -13,6 +13,7 @@ from firebase_admin import auth
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from app.services.mongo_service import (
     delete_trip,
+    create_notification,
 )
 
 security = HTTPBearer()
@@ -231,14 +232,30 @@ async def accept_follow_request(user_id: str, follower_id: str):
     if not follower_doc.exists:
         raise HTTPException(status_code=404, detail="L'usuari seguidor no existeix")
 
-    # Afegir follower a seguidors de user
-    user_ref.update({"llista_seguidors": firestore.ArrayUnion([follower_id])})
-    # Afegir user a seguits de follower
-    follower_ref.update({"llista_seguits": firestore.ArrayUnion([user_id])})
+    # Reutilitzar la lògica de follow per assegurar consistència
+    await follow_user(follower_id, user_id)
 
     # Eliminar de les llistes de sol·licituds pendents
     user_ref.update({"llista_solicitud_seguidors": firestore.ArrayRemove([follower_id])})
     follower_ref.update({"llista_solicitud_seguits": firestore.ArrayRemove([user_id])})
+
+    # Crear notificació de nou seguidor (mateix format que client.ts)
+    try:
+        follower_data = follower_doc.to_dict() or {}
+        extra = {
+            "fromUserName": follower_data.get("nom_i_cognoms") or follower_data.get("username") or "",
+            "fromUserAvatar": follower_data.get("url_foto_perfil", ""),
+        }
+
+        create_notification(
+            from_user_id=follower_id,
+            to_user_id=user_id,
+            type="follow",
+            message="ha començat a seguir-te",
+            extra=extra,
+        )
+    except Exception as e:
+        print(f"[WARN] No s'ha pogut crear la notificació de follow en acceptar la sol·licitud: {e}")
 
     return {"message": "Sol·licitud de seguiment acceptada correctament"}
 

--- a/api/app/routers/users.py
+++ b/api/app/routers/users.py
@@ -212,14 +212,90 @@ async def cancel_follow_request(user_id: str, target_id: str):
     return {"message": "Sol·licitud de seguiment cancel·lada correctament"}
 
 
+@router.post("/accept_follow_request/{user_id}/{follower_id}")
+async def accept_follow_request(user_id: str, follower_id: str):
+    """
+    Accepta una sol·licitud de seguiment.
+    Afegeix follower_id a la llista de seguidors del user_id.
+    Afegeix user_id a la llista de seguits del follower_id.
+    Elimina les sol·licituds pendents.
+    """
+    user_ref = db.collection("users").document(user_id)
+    follower_ref = db.collection("users").document(follower_id)
+
+    user_doc = user_ref.get()
+    follower_doc = follower_ref.get()
+
+    if not user_doc.exists:
+        raise HTTPException(status_code=404, detail="L'usuari no existeix")
+    if not follower_doc.exists:
+        raise HTTPException(status_code=404, detail="L'usuari seguidor no existeix")
+
+    # Afegir follower a seguidors de user
+    user_ref.update({"llista_seguidors": firestore.ArrayUnion([follower_id])})
+    # Afegir user a seguits de follower
+    follower_ref.update({"llista_seguits": firestore.ArrayUnion([user_id])})
+
+    # Eliminar de les llistes de sol·licituds pendents
+    user_ref.update({"llista_solicitud_seguidors": firestore.ArrayRemove([follower_id])})
+    follower_ref.update({"llista_solicitud_seguits": firestore.ArrayRemove([user_id])})
+
+    return {"message": "Sol·licitud de seguiment acceptada correctament"}
+
+
+@router.post("/reject_follow_request/{user_id}/{follower_id}")
+async def reject_follow_request(user_id: str, follower_id: str):
+    """
+    Rebutja una sol·licitud de seguiment.
+    Simplement elimina la sol·licitud pendent sense afegir a seguidors.
+    """
+    user_ref = db.collection("users").document(user_id)
+    follower_ref = db.collection("users").document(follower_id)
+
+    user_doc = user_ref.get()
+    follower_doc = follower_ref.get()
+
+    if not user_doc.exists:
+        raise HTTPException(status_code=404, detail="L'usuari no existeix")
+    if not follower_doc.exists:
+        raise HTTPException(status_code=404, detail="L'usuari seguidor no existeix")
+
+    # Eliminar de les llistes de sol·licituds pendents
+    user_ref.update({"llista_solicitud_seguidors": firestore.ArrayRemove([follower_id])})
+    follower_ref.update({"llista_solicitud_seguits": firestore.ArrayRemove([user_id])})
+
+    return {"message": "Sol·licitud de seguiment rebutjada correctament"}
+
+
 @router.post("/follow/{user_id}/{target_id}")
 async def follow_user(user_id: str, target_id: str):
     """
     Afegeix el target_id a la llista 'llista_seguits' del user_id,
     i afegeix el user_id a la llista 'llista_seguidors' del target_id.
-    
-    Si el target té perfil privat, crea una sol·licitud de seguiment.
-    Si el target té perfil públic, segueix directament.
+    """
+    if user_id == target_id:
+        raise HTTPException(status_code=400, detail="No et pots seguir a tu mateix")
+
+    user_ref = db.collection("users").document(user_id)
+    target_ref = db.collection("users").document(target_id)
+
+    # Comprovació que l'usuari a seguir existeix
+    target_doc = target_ref.get()
+    if not target_doc.exists:
+        raise HTTPException(
+            status_code=404, detail="L'usuari que vols seguir no existeix"
+        )
+
+    user_ref.update({"llista_seguits": firestore.ArrayUnion([target_id])})
+    target_ref.update({"llista_seguidors": firestore.ArrayUnion([user_id])})
+    return {"message": "Usuari seguit correctament"}
+
+
+@router.post("/askToFollowUser/{user_id}/{target_id}")
+async def ask_to_follow_user(user_id: str, target_id: str):
+    """
+    Afegeix el target_id a la llista 'llista_solicitud_seguidors' del user_id,
+    i afegeix el user_id a la llista 'llista_solicitud_seguits' del target_id.
     """
     if user_id == target_id:
         raise HTTPException(status_code=400, detail="No et pots seguir a tu mateix")
@@ -238,16 +314,9 @@ async def follow_user(user_id: str, target_id: str):
     target_data = target_doc.to_dict()
     is_private = target_data.get("isPrivate", False)
 
-    if is_private:
-        # Si és privat, crear una sol·licitud de seguiment
-        target_ref.update({"llista_solicitud_seguidors": firestore.ArrayUnion([user_id])})
-        user_ref.update({"llista_solicitud_seguits": firestore.ArrayUnion([target_id])})
-        return {"message": "Sol·licitud de seguiment enviada correctament"}
-    else:
-        # Si és públic, seguir directament
-        user_ref.update({"llista_seguits": firestore.ArrayUnion([target_id])})
-        target_ref.update({"llista_seguidors": firestore.ArrayUnion([user_id])})
-        return {"message": "Usuari seguit correctament"}
+    target_ref.update({"llista_solicitud_seguidors": firestore.ArrayUnion([user_id])})
+    user_ref.update({"llista_solicitud_seguits": firestore.ArrayUnion([target_id])})
+    return {"message": "Sol·licitud de seguiment enviada correctament"}
 
 
 @router.post("/save/{user_id}/{trip_id}")

--- a/api/app/routers/users.py
+++ b/api/app/routers/users.py
@@ -195,14 +195,13 @@ async def cancel_follow_request(user_id: str, target_id: str):
     # Comprovem que l'usuari existeix
     if not user_doc.exists:
         raise HTTPException(
-            status_code=404, detail="L'usuari que intenta cancel·lar la sol·licitud no existeix"
+            status_code=404,
+            detail="L'usuari que intenta cancel·lar la sol·licitud no existeix",
         )
 
     # Comprovem que l'usuari target existeix
     if not target_doc.exists:
-        raise HTTPException(
-            status_code=404, detail="L'usuari target no existeix"
-        )
+        raise HTTPException(status_code=404, detail="L'usuari target no existeix")
 
     # Eliminar de la llista de sol·licituds enviades
     user_ref.update({"llista_solicitud_seguits": firestore.ArrayRemove([target_id])})
@@ -236,14 +235,18 @@ async def accept_follow_request(user_id: str, follower_id: str):
     await follow_user(follower_id, user_id)
 
     # Eliminar de les llistes de sol·licituds pendents
-    user_ref.update({"llista_solicitud_seguidors": firestore.ArrayRemove([follower_id])})
+    user_ref.update(
+        {"llista_solicitud_seguidors": firestore.ArrayRemove([follower_id])}
+    )
     follower_ref.update({"llista_solicitud_seguits": firestore.ArrayRemove([user_id])})
 
     # Crear notificació de nou seguidor (mateix format que client.ts)
     try:
         follower_data = follower_doc.to_dict() or {}
         extra = {
-            "fromUserName": follower_data.get("nom_i_cognoms") or follower_data.get("username") or "",
+            "fromUserName": follower_data.get("nom_i_cognoms")
+            or follower_data.get("username")
+            or "",
             "fromUserAvatar": follower_data.get("url_foto_perfil", ""),
         }
 
@@ -255,13 +258,17 @@ async def accept_follow_request(user_id: str, follower_id: str):
             extra=extra,
         )
     except Exception as e:
-        print(f"[WARN] No s'ha pogut crear la notificació de follow en acceptar la sol·licitud: {e}")
+        print(
+            f"[WARN] No s'ha pogut crear la notificació de follow en acceptar la sol·licitud: {e}"
+        )
 
     # Crear notificació al sol·licitant informant que se li ha acceptat la sol·licitud
     try:
         user_data = user_doc.to_dict() or {}
         extra_accepted = {
-            "fromUserName": user_data.get("nom_i_cognoms") or user_data.get("username") or "",
+            "fromUserName": user_data.get("nom_i_cognoms")
+            or user_data.get("username")
+            or "",
             "fromUserAvatar": user_data.get("url_foto_perfil", ""),
         }
 
@@ -273,7 +280,9 @@ async def accept_follow_request(user_id: str, follower_id: str):
             extra=extra_accepted,
         )
     except Exception as e:
-        print(f"[WARN] No s'ha pogut crear la notificació d'acceptació al sol·licitant: {e}")
+        print(
+            f"[WARN] No s'ha pogut crear la notificació d'acceptació al sol·licitant: {e}"
+        )
 
     return {"message": "Sol·licitud de seguiment acceptada correctament"}
 
@@ -296,7 +305,9 @@ async def reject_follow_request(user_id: str, follower_id: str):
         raise HTTPException(status_code=404, detail="L'usuari seguidor no existeix")
 
     # Eliminar de les llistes de sol·licituds pendents
-    user_ref.update({"llista_solicitud_seguidors": firestore.ArrayRemove([follower_id])})
+    user_ref.update(
+        {"llista_solicitud_seguidors": firestore.ArrayRemove([follower_id])}
+    )
     follower_ref.update({"llista_solicitud_seguits": firestore.ArrayRemove([user_id])})
 
     return {"message": "Sol·licitud de seguiment rebutjada correctament"}
@@ -424,7 +435,9 @@ async def unblock_user(user_id: str, target_id: str):
     i elimina el user_id de la llista 'llista_bloquejadors' del target_id.
     """
     if user_id == target_id:
-        raise HTTPException(status_code=400, detail="No pots desbloquejar-te a tu mateix")
+        raise HTTPException(
+            status_code=400, detail="No pots desbloquejar-te a tu mateix"
+        )
 
     user_ref = db.collection("users").document(user_id)
     target_ref = db.collection("users").document(target_id)

--- a/api/app/routers/users.py
+++ b/api/app/routers/users.py
@@ -345,10 +345,6 @@ async def ask_to_follow_user(user_id: str, target_id: str):
             status_code=404, detail="L'usuari que vols seguir no existeix"
         )
 
-    # Verificar si el target té perfil privat
-    target_data = target_doc.to_dict()
-    is_private = target_data.get("isPrivate", False)
-
     target_ref.update({"llista_solicitud_seguidors": firestore.ArrayUnion([user_id])})
     user_ref.update({"llista_solicitud_seguits": firestore.ArrayUnion([target_id])})
     return {"message": "Sol·licitud de seguiment enviada correctament"}
@@ -490,39 +486,6 @@ async def add_publicacio(user_id: str, trip_id: str, user=Depends(verify_token))
         "publicacions": list(publicacions),
     }
 
-@router.post("/removefollower/{user_id}/{target_id}")
-async def remove_follower(user_id: str, target_id: str):
-    """
-    Elimina el target_id de la llista de seguidors de user_id.
-    A més, elimina user_id de la llista de seguits del target_id
-    per mantenir la coherència.
-    """
-
-    user_ref = db.collection("users").document(user_id)
-    target_ref = db.collection("users").document(target_id)
-
-    user_doc = user_ref.get()
-    target_doc = target_ref.get()
-
-    if not user_doc.exists:
-        raise HTTPException(
-            status_code=404,
-            detail="L'usuari que rep el seguidor no existeix"
-        )
-
-    if not target_doc.exists:
-        raise HTTPException(
-            status_code=404,
-            detail="L'usuari que vols eliminar de seguidors no existeix"
-        )
-
-    # Eliminar target_id de la llista de seguidors
-    user_ref.update({"llista_seguidors": firestore.ArrayRemove([target_id])})
-
-    # Eliminar user_id de la llista de seguits del target
-    target_ref.update({"llista_seguits": firestore.ArrayRemove([user_id])})
-
-    return {"message": "Seguidor eliminat correctament"}
 
 @router.post("/removefollower/{user_id}/{target_id}")
 async def remove_follower(user_id: str, target_id: str):

--- a/api/app/services/mongo_service.py
+++ b/api/app/services/mongo_service.py
@@ -276,9 +276,7 @@ def mark_notification_as_read(notification_id: str):
 def delete_notification(notification_id: str):
     """Elimina una notificació per ID"""
     try:
-        res = notifications_collection.delete_one(
-            {"_id": ObjectId(notification_id)}
-        )
+        res = notifications_collection.delete_one({"_id": ObjectId(notification_id)})
         return res.deleted_count == 1
     except Exception:
         return False

--- a/api/app/services/mongo_service.py
+++ b/api/app/services/mongo_service.py
@@ -249,6 +249,8 @@ def list_notifications(user_id: str, only_unread: bool = False):
             {
                 "id": str(n["_id"]),
                 "type": n["type"],
+                "fromUserId": n.get("fromUserId"),
+                "toUserId": n.get("toUserId"),
                 "fromUserName": extra.get("fromUserName", "Algú"),
                 "fromUserAvatar": extra.get("fromUserAvatar"),
                 "tripTitle": extra.get("tripTitle"),

--- a/api/app/services/mongo_service.py
+++ b/api/app/services/mongo_service.py
@@ -271,3 +271,14 @@ def mark_notification_as_read(notification_id: str):
         return res.modified_count == 1
     except Exception:
         return False
+
+
+def delete_notification(notification_id: str):
+    """Elimina una notificació per ID"""
+    try:
+        res = notifications_collection.delete_one(
+            {"_id": ObjectId(notification_id)}
+        )
+        return res.deleted_count == 1
+    except Exception:
+        return False

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -141,7 +141,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -551,7 +550,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -575,7 +573,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1300,7 +1297,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.4.tgz",
       "integrity": "sha512-pUxEGmR+uu21OG/icAovjlu1fcYJzyVhhT0rsCrn+zi+nHtrS43Bp9KPn9KGa4NMspCUE++nkyiqziuIvJdwzw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.0",
         "@firebase/logger": "0.5.0",
@@ -1367,7 +1363,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.4.tgz",
       "integrity": "sha512-T7ifGmb+awJEcp542Ek4HtNfBxcBrnuk1ggUdqyFEdsXHdq7+wVlhvE6YukTL7NS8hIkEfL7TMAPx/uCNqt30g==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/app": "0.14.4",
         "@firebase/component": "0.7.0",
@@ -1383,8 +1378,7 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@firebase/auth": {
       "version": "1.11.0",
@@ -1835,7 +1829,6 @@
       "integrity": "sha512-0AZUyYUfpMNcztR5l09izHwXkZpghLgCUaAGjtMwXnCg3bj4ml5VgiwqOMOxJ+Nw4qN/zJAaOQBcJ7KGkWStqQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -3084,7 +3077,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3184,7 +3178,6 @@
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -3195,7 +3188,6 @@
       "integrity": "sha512-/EEvYBdT3BflCWvTMO7YkYBHVE9Ci6XdqZciZANQgKpaiDRGOLIlRo91jbTNRQjgPFWVaRxcYc0luVNFitz57A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3264,7 +3256,6 @@
       "integrity": "sha512-n1H6IcDhmmUEG7TNVSspGmiHHutt7iVKtZwRppD7e04wha5MrkV1h3pti9xQLcCMt6YWsncpoT0HMjkH1FNwWQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.0",
         "@typescript-eslint/types": "8.46.0",
@@ -3636,7 +3627,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3858,7 +3848,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -4316,7 +4305,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -4526,7 +4516,6 @@
       "integrity": "sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5423,7 +5412,10 @@
         }
       ],
       "license": "MIT",
+<<<<<<< HEAD
       "peer": true,
+=======
+>>>>>>> US-4.1.1
       "dependencies": {
         "@babel/runtime": "^7.28.4"
       },
@@ -5716,7 +5708,6 @@
       "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.1.0",
         "data-urls": "^5.0.0",
@@ -6186,6 +6177,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -6798,7 +6790,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6848,7 +6839,6 @@
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -6880,6 +6870,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -6895,6 +6886,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -6988,7 +6980,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -7502,7 +7493,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-tokenizer": "^3.0.4",
@@ -7748,8 +7738,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.14.tgz",
       "integrity": "sha512-b7pCxjGO98LnxVkKjaZSDeNuljC4ueKUddjENJOADtubtdo8llTaJy7HwBMeLNSSo2N5QIAgklslK1+Ir8r6CA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -7888,7 +7877,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8036,7 +8024,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8148,7 +8135,6 @@
       "integrity": "sha512-4nVGliEpxmhCL8DslSAUdxlB6+SMrhB0a1v5ijlh1xB1nEPuy1mxaHxysVucLHuWryAxLWg6a5ei+U4TLn/rFg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -8755,7 +8741,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9293,7 +9278,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -69,15 +69,39 @@ export async function getAllUsers() {
   return apiGet("/users");
 }
 
+// Seguir un usuari
 export async function followUser(userId: string, targetId: string) {
   const res = await apiPost(`/users/follow/${userId}/${targetId}`, {});
+
+  try {
+    const userData = await getUserById(userId);
+
+    await createNotification({
+      fromUserId: userId,
+      toUserId: targetId,
+      type: "follow",
+      message: "ha començat a seguir-te",
+      extra: {
+        fromUserName: userData.nom_i_cognoms ?? userData.username ?? "",
+        fromUserAvatar: userData.url_foto_perfil ?? "",
+      },
+    });
+  } catch (e) {
+    console.warn("⚠️ No s'ha pogut crear la notificació de follow:", e);
+  }
+
+  return res;
+}
+
+// Enviar sol·licitud de seguiment
+export async function askToFollowUser(userId: string, targetId: string) {
+  const res = await apiPost(`/users/askToFollowUser/${userId}/${targetId}`, {});
 
   try {
     const userData = await getUserById(userId);
     const targetUserData = await getUserById(targetId);
 
     if (targetUserData.isPrivate) {
-      // Si l'usuari a seguir és privat, s'envia una sol·licitud de seguiment
       await createNotification({
         fromUserId: userId,
         toUserId: targetId,
@@ -89,26 +113,15 @@ export async function followUser(userId: string, targetId: string) {
           actionButton: true,
         },
       });
-    } else {
-      // Si l'usuari a seguir és públic, s'envia una notificación simple
-      await createNotification({
-        fromUserId: userId,
-        toUserId: targetId,
-        type: "follow",
-        message: "ha començat a seguir-te",
-        extra: {
-          fromUserName: userData.nom_i_cognoms ?? userData.username ?? "",
-          fromUserAvatar: userData.url_foto_perfil ?? "",
-        },
-      });
     }
   } catch (e) {
-    console.warn("⚠️ No s'ha pogut crear la notificació de follow:", e);
+    console.warn("⚠️ No s'ha pogut crear la sol·licitud de follow:", e);
   }
 
   return res;
 }
 
+// Deixar de seguir un usuari
 export async function unfollowUser(userId: string, targetId: string) {
   const res = await apiPost(`/users/unfollow/${userId}/${targetId}`, {});
 
@@ -135,6 +148,16 @@ export async function unfollowUser(userId: string, targetId: string) {
 // Eliminar sol·licitud de seguiment
 export async function cancel_follow_request(userId: string, targetId: string) {
   return apiPost(`/users/cancel_follow_request/${userId}/${targetId}`, {});
+}
+
+// Acceptar sol·licitud de seguiment
+export async function accept_follow_request(userId: string, targetId: string) {
+  return apiPost(`/users/accept_follow_request/${userId}/${targetId}`, {});
+}
+
+// Rebutjar sol·licitud de seguiment
+export async function reject_follow_request(userId: string, targetId: string) {
+  return apiPost(`/users/reject_follow_request/${userId}/${targetId}`, {});
 }
 
 // Guardar una ruta
@@ -193,13 +216,12 @@ export async function removePublication(userId: string, tripId: string) {
   return apiDelete(`/users/${userId}/publicacions/${tripId}`);
 }
 
-// (opcional) si ja no el fas servir, pots BORRAR aquesta funció
 export async function deleteTripAndPublication(userId: string, tripId: string) {
   await deleteTripById(tripId);
   await removePublication(userId, tripId);
 }
 
-// 🔻 NOVA: eliminar compte completament (backend: DELETE /users/delete/{user_id})
+// eliminar compte completament (backend: DELETE /users/delete/{user_id})
 export async function deleteAccount(userId: string) {
   return apiDelete(`/users/delete/${userId}`);
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -49,6 +49,7 @@ export async function registerUser(data: {
   fullname: string;
   username: string;
   mail: string;
+  isPrivate?: boolean;
 }) {
   return apiPost("/users/register", data);
 }
@@ -118,7 +119,10 @@ export async function unfollowUser(userId: string, targetId: string) {
   return res;
 }
 
-
+// Eliminar sol·licitud de seguiment
+export async function cancel_follow_request(userId: string, targetId: string) {
+  return apiPost(`/users/cancel_follow_request/${userId}/${targetId}`, {});
+}
 
 // Guardar una ruta
 export async function saveTrip(userId: string, tripId: string) {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -70,23 +70,38 @@ export async function getAllUsers() {
 }
 
 export async function followUser(userId: string, targetId: string) {
-  // 1) Ejecutar acción follow en backend
   const res = await apiPost(`/users/follow/${userId}/${targetId}`, {});
 
   try {
-    // 2) Obtener datos del usuario que sigue
     const userData = await getUserById(userId);
+    const targetUserData = await getUserById(targetId);
 
-    await createNotification({
-      fromUserId: userId,
-      toUserId: targetId,
-      type: "follow",
-      message: "ha començat a seguir-te",
-      extra: {
-        fromUserName: userData.nom_i_cognoms ?? userData.username ?? "",
-        fromUserAvatar: userData.url_foto_perfil ?? "",
-      },
-    });
+    if (targetUserData.isPrivate) {
+      // Si l'usuari a seguir és privat, s'envia una sol·licitud de seguiment
+      await createNotification({
+        fromUserId: userId,
+        toUserId: targetId,
+        type: "follow_request",
+        message: "t'ha enviat una sol·licitud de seguiment",
+        extra: {
+          fromUserName: userData.nom_i_cognoms ?? userData.username ?? "",
+          fromUserAvatar: userData.url_foto_perfil ?? "",
+          actionButton: true,
+        },
+      });
+    } else {
+      // Si l'usuari a seguir és públic, s'envia una notificación simple
+      await createNotification({
+        fromUserId: userId,
+        toUserId: targetId,
+        type: "follow",
+        message: "ha començat a seguir-te",
+        extra: {
+          fromUserName: userData.nom_i_cognoms ?? userData.username ?? "",
+          fromUserAvatar: userData.url_foto_perfil ?? "",
+        },
+      });
+    }
   } catch (e) {
     console.warn("⚠️ No s'ha pogut crear la notificació de follow:", e);
   }
@@ -95,11 +110,9 @@ export async function followUser(userId: string, targetId: string) {
 }
 
 export async function unfollowUser(userId: string, targetId: string) {
-  // 1) Ejecutar acción unfollow en backend
   const res = await apiPost(`/users/unfollow/${userId}/${targetId}`, {});
 
   try {
-    // 2) Obtener datos del usuario que deja de seguir
     const userData = await getUserById(userId);
 
     await createNotification({

--- a/frontend/src/api/notifier.ts
+++ b/frontend/src/api/notifier.ts
@@ -73,3 +73,18 @@ export async function createNotification(data: {
 export async function markNotificationAsRead(notificationId: string) {
   return apiPut(`/notifications/read/${notificationId}`);
 }
+
+export async function deleteNotification(notificationId: string) {
+  const user = getAuth().currentUser;
+  const token = user ? await user.getIdToken() : null;
+
+  const res = await fetch(`${API_URL}/notifications/${notificationId}`, {
+    method: "DELETE",
+    headers: {
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+  });
+
+  if (!res.ok) throw new Error(`API Error ${res.status}`);
+  return res.json();
+}

--- a/frontend/src/components/Mailbox.tsx
+++ b/frontend/src/components/Mailbox.tsx
@@ -1,6 +1,6 @@
 import { X, Mail, Bell, MessageCircle, Star } from "lucide-react";
 import "../styles/MailBox.css";
-import { accept_follow_request, reject_follow_request, followUser } from "../api/client";
+import { accept_follow_request, reject_follow_request } from "../api/client";
 import { auth } from "../firebase";
 import { deleteNotification } from "../api/notifier";
 
@@ -24,6 +24,8 @@ type Props = {
   onClose: () => void;
   notifications?: Notification[];
   onMarkRead?: (id: string) => void;
+  onAfterAccept?: (id: string) => Promise<void> | void;
+  onAfterReject?: (id: string) => Promise<void> | void;
 };
 
 function formatDate(dateStr: string) {
@@ -52,32 +54,38 @@ function getIcon(type: NotificationType) {
   }
 }
 
-export default function Mailbox({ open, onClose, notifications, onMarkRead }: Props) {
+export default function Mailbox({ open, onClose, notifications, onMarkRead, onAfterAccept, onAfterReject }: Props) {
   if (!open) return null;
 
   const items = notifications || [];
   const unreadCount = items.filter((n) => !n.read).length;
 
   const handleAccept = async (notification: Notification) => {
-  if (!auth.currentUser) return;
+    if (!auth.currentUser) return;
 
-  const currentUserId = auth.currentUser.uid;
-  const fromUserId = notification.fromUserId;
+    const currentUserId = auth.currentUser.uid;
+    const fromUserId = notification.fromUserId;
 
-  
-  try {
-    if (!fromUserId) {
-      alert("No es pot acceptar la sol·licitud: manca l'ID de l'usuari.");
-    } else {
-      await accept_follow_request(currentUserId, fromUserId); // acceptar la sol·licitud
+    try {
+      if (!fromUserId) {
+        alert("No es pot acceptar la sol·licitud: manca l'ID de l'usuari.");
+      } else {
+        await accept_follow_request(currentUserId, fromUserId);
+      }
+    } catch (err) {
+      console.error(err);
+      alert("Error al acceptar la sol·licitud de seguiment.");
+    } finally {
+      await deleteNotification(notification.id);
+      if (onAfterAccept) {
+        try {
+          await onAfterAccept(notification.id);
+        } catch (cbErr) {
+          console.error("Error després d'acceptar:", cbErr);
+        }
+      }
     }
-  } catch (err) {
-    console.error(err);
-    alert("Error al acceptar la sol·licitud de seguiment.");
-  } finally {
-    await deleteNotification(notification.id);  // eliminar la notificació
-  }
-};
+  };
 
 const handleReject = async (notification: Notification) => {
   if (!auth.currentUser) return;
@@ -96,6 +104,13 @@ const handleReject = async (notification: Notification) => {
     alert("Error al rebuthar la sol·licitud de seguiment.");
   } finally {
     await deleteNotification(notification.id);  // eliminar la notificació
+    if (onAfterReject) {
+      try {
+        await onAfterReject(notification.id);
+      } catch (cbErr) {
+        console.error("Error després de rebutjar:", cbErr);
+      }
+    }
   }
 };
 

--- a/frontend/src/components/Mailbox.tsx
+++ b/frontend/src/components/Mailbox.tsx
@@ -1,11 +1,16 @@
 import { X, Mail, Bell, MessageCircle, Star } from "lucide-react";
 import "../styles/MailBox.css";
+import { accept_follow_request, reject_follow_request, followUser } from "../api/client";
+import { auth } from "../firebase";
+import { deleteNotification } from "../api/notifier";
 
 export type NotificationType = "follow" | "follow_request" | "comment" | "rating";
 
 export type Notification = {
   id: string;
   type: NotificationType;
+  fromUserId: string;
+  toUserId: string;
   fromUserName: string;
   fromUserAvatar?: string;
   tripTitle?: string;
@@ -18,7 +23,7 @@ type Props = {
   open: boolean;
   onClose: () => void;
   notifications?: Notification[];
-  onMarkRead?: (id: string) => void; // NUEVO
+  onMarkRead?: (id: string) => void;
 };
 
 function formatDate(dateStr: string) {
@@ -52,6 +57,48 @@ export default function Mailbox({ open, onClose, notifications, onMarkRead }: Pr
 
   const items = notifications || [];
   const unreadCount = items.filter((n) => !n.read).length;
+
+  const handleAccept = async (notification: Notification) => {
+  if (!auth.currentUser) return;
+
+  const currentUserId = auth.currentUser.uid;
+  const fromUserId = notification.fromUserId;
+
+  
+  try {
+    if (!fromUserId) {
+      alert("No es pot acceptar la sol·licitud: manca l'ID de l'usuari.");
+    } else {
+      await accept_follow_request(currentUserId, fromUserId); // acceptar la sol·licitud
+      await followUser(fromUserId, currentUserId);  // fer que ens segueixi l'usuari
+    }
+  } catch (err) {
+    console.error(err);
+    alert("Error al acceptar la sol·licitud de seguiment.");
+  } finally {
+    await deleteNotification(notification.id);  // eliminar la notificació
+  }
+};
+
+const handleReject = async (notification: Notification) => {
+  if (!auth.currentUser) return;
+
+  const currentUserId = auth.currentUser.uid;
+  const fromUserId = notification.fromUserId;
+
+  try {
+    if (!fromUserId) {
+      alert("No es pot rebutjar la sol·licitud: manca l'ID de l'usuari.");
+    } else {
+      await reject_follow_request(currentUserId, fromUserId); // rebutjar la sol·licitud
+    }
+  } catch (err) {
+    console.error(err);
+    alert("Error al rebuthar la sol·licitud de seguiment.");
+  } finally {
+    await deleteNotification(notification.id);  // eliminar la notificació
+  }
+};
 
   return (
     <div
@@ -112,8 +159,8 @@ export default function Mailbox({ open, onClose, notifications, onMarkRead }: Pr
 
                   {n.type === "follow_request" && !n.read && (
                     <div className="follow-request-actions">
-                      <button onClick={() => acceptFollowRequest(n.id)}>Acceptar</button>
-                      <button onClick={() => rejectFollowRequest(n.id)}>Rebutjar</button>
+                      <button onClick={() => handleAccept(n)}>Acceptar</button>
+                      <button onClick={() => handleReject(n)}>Rebutjar</button>
                     </div>
                   )}
 

--- a/frontend/src/components/Mailbox.tsx
+++ b/frontend/src/components/Mailbox.tsx
@@ -1,7 +1,7 @@
 import { X, Mail, Bell, MessageCircle, Star } from "lucide-react";
 import "../styles/MailBox.css";
 
-export type NotificationType = "follow" | "comment" | "rating";
+export type NotificationType = "follow" | "follow_request" | "comment" | "rating";
 
 export type Notification = {
   id: string;
@@ -36,6 +36,8 @@ function getIcon(type: NotificationType) {
   switch (type) {
     case "follow":
       return <Bell size={18} />;
+    case "follow_request":
+      return <Mail size={18} />;
     case "comment":
       return <MessageCircle size={18} />;
     case "rating":
@@ -107,6 +109,13 @@ export default function Mailbox({ open, onClose, notifications, onMarkRead }: Pr
                       )}
                     </div>
                   </div>
+
+                  {n.type === "follow_request" && !n.read && (
+                    <div className="follow-request-actions">
+                      <button onClick={() => acceptFollowRequest(n.id)}>Acceptar</button>
+                      <button onClick={() => rejectFollowRequest(n.id)}>Rebutjar</button>
+                    </div>
+                  )}
 
                   {!n.read && <span className="mailbox-dot" />}
                 </li>

--- a/frontend/src/components/Mailbox.tsx
+++ b/frontend/src/components/Mailbox.tsx
@@ -70,7 +70,6 @@ export default function Mailbox({ open, onClose, notifications, onMarkRead }: Pr
       alert("No es pot acceptar la sol·licitud: manca l'ID de l'usuari.");
     } else {
       await accept_follow_request(currentUserId, fromUserId); // acceptar la sol·licitud
-      await followUser(fromUserId, currentUserId);  // fer que ens segueixi l'usuari
     }
   } catch (err) {
     console.error(err);

--- a/frontend/src/components/RegisterModal.tsx
+++ b/frontend/src/components/RegisterModal.tsx
@@ -20,6 +20,8 @@ export default function RegisterModal({ onClose, openLogin }: RegisterProps) {
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
+  const [isPrivate, setIsPrivate] = useState(false); // false = públic per defecte
+
   const navigate = useNavigate();
 
   const handleRegister = async (e: React.FormEvent) => {
@@ -38,7 +40,7 @@ export default function RegisterModal({ onClose, openLogin }: RegisterProps) {
 
     try {
       setLoading(true);
-      await Auth.register(fullName, username, email, password);
+      await Auth.register(fullName, username, email, password, isPrivate);
       onClose();
       navigate("/");
     } catch (err: any) {
@@ -128,6 +130,7 @@ export default function RegisterModal({ onClose, openLogin }: RegisterProps) {
                   className="password-toggle"
                   onClick={() => setShowPassword((prev) => !prev)}
                 >
+                  {/* aquí l'icona de l'ull si la tens */}
                 </button>
               )}
             </div>
@@ -153,9 +156,37 @@ export default function RegisterModal({ onClose, openLogin }: RegisterProps) {
                   className="password-toggle"
                   onClick={() => setShowConfirmPassword((prev) => !prev)}
                 >
+                  {/* icona */}
                 </button>
               )}
+            </div>
 
+            {/* 🔐 Privacitat del perfil */}
+            <div className="privacy-section">
+
+              <div className="privacy-options">
+                <label className="privacy-option">
+                  <input
+                    type="radio"
+                    name="privacy"
+                    value="public"
+                    checked={!isPrivate}
+                    onChange={() => setIsPrivate(false)}
+                  />
+                  <span>Perfil públic</span>
+                </label>
+
+                <label className="privacy-option">
+                  <input
+                    type="radio"
+                    name="privacy"
+                    value="private"
+                    checked={isPrivate}
+                    onChange={() => setIsPrivate(true)}
+                  />
+                  <span>Perfil privat</span>
+                </label>
+              </div>
             </div>
 
             <button type="submit" className="auth-button" disabled={loading}>
@@ -169,7 +200,10 @@ export default function RegisterModal({ onClose, openLogin }: RegisterProps) {
               {t('register_has_account')}{" "}
             <button
               type="button"
-              onClick={() => { onClose(); openLogin(); }}
+              onClick={() => {
+                onClose();
+                openLogin();
+              }}
               className="auth-link"
             >
                 {t('register_login_here')}

--- a/frontend/src/components/UserSettings.tsx
+++ b/frontend/src/components/UserSettings.tsx
@@ -3,7 +3,7 @@ import "../styles/UserSettings.css";
 import { X } from "lucide-react";
 import { auth } from "../firebase";
 import { signOut } from "firebase/auth";
-import { deleteAccount, accept_follow_request } from "../api/client";
+import { deleteAccount, accept_follow_request, getUserById } from "../api/client";
 import { getNotifications, deleteNotification } from "../api/notifier";
 import i18n from "../i18n/i18n";
 import { useTranslation } from 'react-i18next';
@@ -83,10 +83,9 @@ export default function UserSettings({ open, profile, onClose, onSavePrivacy }: 
         throw new Error(err.detail || t('profile_error_updating'));
       }
 
-      // Actualitzem l'estat local
       setIsPrivate(newPrivacy);
 
-      const updatedProfile: BackendUser = {
+      let updatedProfile: BackendUser = {
         ...profile,
         isPrivate: newPrivacy,
       };
@@ -125,6 +124,24 @@ export default function UserSettings({ open, profile, onClose, onSavePrivacy }: 
           console.error("⚠️ Error acceptant sol·licituds pendents:", err);
           // No aturem l'execució, ja que el perfil s'ha canviat correctament
         }
+      }
+
+      try {
+        const refreshedProfile = await getUserById(profile.uid);
+        updatedProfile = {
+          ...refreshedProfile,
+          llista_seguidors: refreshedProfile.llista_seguidors || [],
+          llista_seguits: refreshedProfile.llista_seguits || [],
+          llista_solicitud_seguidors: refreshedProfile.llista_solicitud_seguidors || [],
+          llista_solicitud_seguits: refreshedProfile.llista_solicitud_seguits || [],
+          publicacions: refreshedProfile.publicacions || [],
+          guardades: refreshedProfile.guardades || [],
+          llista_bloquejats: refreshedProfile.llista_bloquejats || [],
+          llista_bloquejadors: refreshedProfile.llista_bloquejadors || [],
+        } as BackendUser;
+        setIsPrivate(updatedProfile.isPrivate || false);
+      } catch (err) {
+        console.error("⚠️ Error refrescant el perfil després del canvi de privacitat:", err);
       }
 
       if (onSavePrivacy) onSavePrivacy(updatedProfile);

--- a/frontend/src/components/UserSettings.tsx
+++ b/frontend/src/components/UserSettings.tsx
@@ -3,7 +3,8 @@ import "../styles/UserSettings.css";
 import { X } from "lucide-react";
 import { auth } from "../firebase";
 import { signOut } from "firebase/auth";
-import { deleteAccount } from "../api/client";
+import { deleteAccount, accept_follow_request } from "../api/client";
+import { getNotifications, deleteNotification } from "../api/notifier";
 import i18n from "../i18n/i18n";
 import { useTranslation } from 'react-i18next';
 import type { BackendUser } from "../pages/UserProfile";
@@ -89,6 +90,42 @@ export default function UserSettings({ open, profile, onClose, onSavePrivacy }: 
         ...profile,
         isPrivate: newPrivacy,
       };
+
+      // Si canvia a públic (newPrivacy === false)
+      if (!newPrivacy) {
+        try {
+          // 1. Acceptar totes les sol·licituds pendents
+          if (profile.llista_solicitud_seguidors && profile.llista_solicitud_seguidors.length > 0) {
+            const pendingRequests = profile.llista_solicitud_seguidors;
+            
+            for (const fromUserId of pendingRequests) {
+              await accept_follow_request(profile.uid, fromUserId);
+            }
+            console.log(`✅ S'han acceptat ${pendingRequests.length} sol·licituds pendents`);
+          }
+
+          // 2. Eliminar TOTES les notificacions de sol·licitud de seguiment (independentment del seu origen)
+          try {
+            const notifications = await getNotifications(profile.uid, false);
+            const followRequestNotifs = notifications.filter(
+              (n: any) => n.type === "follow_request"
+            );
+
+            for (const notif of followRequestNotifs) {
+              await deleteNotification(notif.id);
+            }
+
+            if (followRequestNotifs.length > 0) {
+              console.log(`🗑️ S'han eliminat ${followRequestNotifs.length} notificacions de sol·licitud de seguiment`);
+            }
+          } catch (err) {
+            console.error("⚠️ Error eliminant notificacions:", err);
+          }
+        } catch (err) {
+          console.error("⚠️ Error acceptant sol·licituds pendents:", err);
+          // No aturem l'execució, ja que el perfil s'ha canviat correctament
+        }
+      }
 
       if (onSavePrivacy) onSavePrivacy(updatedProfile);
     } catch (e: any) {

--- a/frontend/src/components/UserSettings.tsx
+++ b/frontend/src/components/UserSettings.tsx
@@ -5,12 +5,15 @@ import { auth } from "../firebase";
 import { signOut } from "firebase/auth";
 import { deleteAccount } from "../api/client";
 import i18n from "../i18n/i18n";
-import { useTranslation } from 'react-i18next'; // Importa el hook
+import { useTranslation } from 'react-i18next';
+import type { BackendUser } from "../pages/UserProfile";
 
 
 type Props = {
   open: boolean;
   onClose: () => void;
+  profile: BackendUser;
+  onSavePrivacy?: (updatedProfile: BackendUser) => void;
 };
 
 // Funció per decidir tema inicial (localStorage o preferència del sistema)
@@ -24,7 +27,7 @@ function getInitialTheme(): "light" | "dark" {
   return prefersDark ? "dark" : "light";
 }
 
-export default function UserSettings({ open, onClose }: Props) {
+export default function UserSettings({ open, profile, onClose, onSavePrivacy }: Props) {
   const { t } = useTranslation();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
@@ -33,14 +36,16 @@ export default function UserSettings({ open, onClose }: Props) {
 
   const [language, setLanguage] = useState(i18n.language || "ca");
 
+  const [privacyLoading, setPrivacyLoading] = useState(false);
+  const [isPrivate, setIsPrivate] = useState(profile.isPrivate || false);
+
   const changeLanguage = (lng: string) => {
       i18n.changeLanguage(lng);
       setLanguage(lng);
       localStorage.setItem("lang", lng);
   };
 
-
-    // Cada cop que canvia el tema → actualitzem l'HTML i el guardem
+  // Cada cop que canvia el tema → actualitzem l'HTML i el guardem
   useEffect(() => {
     document.documentElement.setAttribute("data-theme", theme);
     localStorage.setItem("theme", theme);
@@ -48,6 +53,50 @@ export default function UserSettings({ open, onClose }: Props) {
 
   const toggleTheme = () => {
     setTheme((prev) => (prev === "light" ? "dark" : "light"));
+  };
+
+  const handleChangePrivacy = async (newPrivacy: boolean) => {
+    try {
+      setPrivacyLoading(true);
+      setError("");
+
+      const formData = new FormData();
+
+      const jsonData = {
+        isPrivate: newPrivacy,
+      };
+
+      // FastAPI requereix user_json com string
+      formData.append("user_json", JSON.stringify(jsonData));
+
+      const response = await fetch(
+        `http://127.0.0.1:8000/users/update/${profile.uid}`,
+        {
+          method: "PATCH",
+          body: formData,
+        }
+      );
+
+      if (!response.ok) {
+        const err = await response.json();
+        throw new Error(err.detail || t('profile_error_updating'));
+      }
+
+      // Actualitzem l'estat local
+      setIsPrivate(newPrivacy);
+
+      const updatedProfile: BackendUser = {
+        ...profile,
+        isPrivate: newPrivacy,
+      };
+
+      if (onSavePrivacy) onSavePrivacy(updatedProfile);
+    } catch (e: any) {
+      console.error(t('error'), e);
+      setError(e?.message || t('profile_error_updating'));
+    } finally {
+      setPrivacyLoading(false);
+    }
   };
 
   if (!open) return null;
@@ -100,7 +149,6 @@ export default function UserSettings({ open, onClose }: Props) {
         <h2 className="settings-title">{t('profile_settings_button')}</h2>
 
         <div className="settings-content">
-          {/* 🌙 Aparença / Mode fosc */}
           <div className="settings-section">
             <h3 className="settings-subtitle">{t('settings_subtitle_appearance')}</h3>
 
@@ -131,32 +179,63 @@ export default function UserSettings({ open, onClose }: Props) {
             </div>
           </div>
 
-            <div className="settings-section">
-                <h3 className="settings-subtitle">{t('language')}</h3>
+          <div className="settings-section">
+            <h3 className="settings-subtitle">Privacitat</h3>
 
-                <div className="settings-row">
-                    <div className="settings-row-info">
-                        <span className="settings-row-label">{t('select_language')}</span>
-                    </div>
+            <div className="settings-row">
+              <div className="settings-row-info">
+                <span className="settings-row-label">
+                  Perfil {isPrivate ? "privat" : "públic"}
+                </span>
+                <span className="settings-row-helper">
+                  {isPrivate
+                    ? "Només els seguidors aprovats podran veure el teu perfil i les teves rutes."
+                    : "Qualsevol usuari podrà veure el teu perfil i les teves rutes."}
+                </span>
+              </div>
 
-                    <div className="settings-select-wrapper">
-                      <select
-                        className="settings-select"
-                        value={language}
-                        onChange={(e) => changeLanguage(e.target.value)}
-                      >
-                        <option value="ca">Català</option>
-                        <option value="es">Castellà</option>
-                        <option value="en">English</option>
-                      </select>
-                      <span className="settings-select-arrow">▾</span>
-                    </div>
-
+              {/* Toggle senzill per privacitat (reutilitza l'estil) */}
+              <label className="toggle-wrapper">
+                <input
+                  type="checkbox"
+                  className="toggle-checkbox"
+                  checked={isPrivate}
+                  onChange={(e) => handleChangePrivacy(e.target.checked)}
+                  disabled={privacyLoading}
+                />
+                <div className="toggle-slot">
+                  <div className="toggle-button" />
                 </div>
+              </label>
             </div>
+          </div>
+
+          <div className="settings-section">
+              <h3 className="settings-subtitle">{t('language')}</h3>
+
+              <div className="settings-row">
+                  <div className="settings-row-info">
+                      <span className="settings-row-label">{t('select_language')}</span>
+                  </div>
+
+                  <div className="settings-select-wrapper">
+                    <select
+                      className="settings-select"
+                      value={language}
+                      onChange={(e) => changeLanguage(e.target.value)}
+                    >
+                      <option value="ca">Català</option>
+                      <option value="es">Castellà</option>
+                      <option value="en">English</option>
+                    </select>
+                    <span className="settings-select-arrow">▾</span>
+                  </div>
+
+              </div>
+          </div>
 
 
-            {/* 🗑️ Secció eliminar compte */}
+          {/* 🗑️ Secció eliminar compte */}
           <div className="settings-section">
             <p className="settings-warning">
                 {t('settings_warning_delete')}

--- a/frontend/src/firebase/auth.ts
+++ b/frontend/src/firebase/auth.ts
@@ -20,13 +20,21 @@ class AuthService {
    * 2. Actualitza displayName
    * 3. Crida al backend /users/register amb token
    */
-  async register(fullname: string, username: string, mail: string, password: string) {
+  async register(
+    fullname: string,
+    username: string,
+    mail: string,
+    password: string,
+    isPrivate: boolean = false   // 🔐 nou paràmetre amb valor per defecte
+  ) {
     const userCredential = await createUserWithEmailAndPassword(auth, mail, password);
     const user = userCredential.user;
 
     await updateProfile(user, { displayName: fullname });
 
-    await registerUser({ fullname, username, mail });
+    await registerUser({ fullname, username, mail, isPrivate });
+
+    localStorage.setItem("uid", user.uid);
 
     localStorage.setItem("uid", user.uid);
 
@@ -65,7 +73,6 @@ class AuthService {
     return auth.currentUser;
   }
 
-  
   async resetPassword(email: string) {
     if (!email) throw new Error("El email és obligatori");
 
@@ -74,14 +81,15 @@ class AuthService {
       return true;
     } catch (error: any) {
       console.error("Error al enviar correu de reset:", error);
-      throw new Error(error.message || "No s'ha pogut enviar l'enllaç de recuperació.");
+      throw new Error(
+        error.message || "No s'ha pogut enviar l'enllaç de recuperació."
+      );
     }
   }
 }
 
 export const Auth = new AuthService();
 export { auth };
-
 
 //Per cridar al endpoint de elminar compte, per poder obtenir el verify token s'ha d'utilitzar el següent:
 //firebase.auth().currentUser.getIdToken(/* forceRefresh */ true), si no funciona probar el següent:

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -7,27 +7,27 @@ export default function useNotifications() {
   const [notifications, setNotifications] = useState<Notification[]>([]);
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    async function fetchData() {
-      const user = getAuth().currentUser;
+  const fetchNotifications = async () => {
+    const user = getAuth().currentUser;
 
-      if (!user) {
-        setNotifications([]);
-        setLoading(false);
-        return;
-      }
-
-      try {
-        const data = await getNotifications(user.uid);
-        setNotifications(data);
-      } catch (err) {
-        console.error("Error carregant notificacions:", err);
-      } finally {
-        setLoading(false);
-      }
+    if (!user) {
+      setNotifications([]);
+      setLoading(false);
+      return;
     }
 
-    fetchData();
+    try {
+      const data = await getNotifications(user.uid);
+      setNotifications(data);
+    } catch (err) {
+      console.error("Error carregant notificacions:", err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchNotifications();
   }, []);
 
   const markRead = async (id: string) => {
@@ -41,5 +41,13 @@ export default function useNotifications() {
     }
   };
 
-  return { notifications, loading, markRead };
+  const refreshNotifications = async () => {
+    await fetchNotifications();
+  };
+
+  const removeLocal = (id: string) => {
+    setNotifications((prev) => prev.filter((n) => n.id !== id));
+  };
+
+  return { notifications, loading, markRead, refreshNotifications, removeLocal };
 }

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -1,23 +1,24 @@
 import { useEffect, useState } from "react";
 import { getNotifications, markNotificationAsRead } from "../api/notifier";
-import { getAuth } from "firebase/auth";
+import { getAuth, onAuthStateChanged } from "firebase/auth";
 import type { Notification } from "../components/Mailbox";
 
 export default function useNotifications() {
   const [notifications, setNotifications] = useState<Notification[]>([]);
   const [loading, setLoading] = useState(true);
+  const auth = getAuth();
 
-  const fetchNotifications = async () => {
-    const user = getAuth().currentUser;
+  const fetchNotifications = async (userId?: string) => {
+    const uid = userId || auth.currentUser?.uid;
 
-    if (!user) {
+    if (!uid) {
       setNotifications([]);
       setLoading(false);
       return;
     }
 
     try {
-      const data = await getNotifications(user.uid);
+      const data = await getNotifications(uid);
       setNotifications(data);
     } catch (err) {
       console.error("Error carregant notificacions:", err);
@@ -27,8 +28,19 @@ export default function useNotifications() {
   };
 
   useEffect(() => {
-    fetchNotifications();
-  }, []);
+    const unsubscribe = onAuthStateChanged(auth, (user) => {
+      if (!user) {
+        setNotifications([]);
+        setLoading(false);
+        return;
+      }
+
+      setLoading(true);
+      fetchNotifications(user.uid);
+    });
+
+    return () => unsubscribe();
+  }, [auth]);
 
   const markRead = async (id: string) => {
     try {
@@ -42,6 +54,7 @@ export default function useNotifications() {
   };
 
   const refreshNotifications = async () => {
+    setLoading(true);
     await fetchNotifications();
   };
 

--- a/frontend/src/i18n/ca.json
+++ b/frontend/src/i18n/ca.json
@@ -27,6 +27,7 @@
   "route_detail_followers": "seguidor",
   "route_detail_followers_plural": "seguidors",
   "route_detail_following": "Seguint",
+  "route_detail_pending": "Pendent",
   "route_detail_follow": "Seguir",
   "route_detail_description_title": "Descripció",
   "route_detail_stages_title": "Etapes de la Ruta",
@@ -71,6 +72,9 @@
   "profile_public_login_follow_hint": "Has d'iniciar sessió per seguir usuaris",
   "profile_error_unfollowing": "Error seguint/seguint deixant:",
   "profile_have_to_login": "Has de iniciar sessió per interactuar",
+  "user_profile_follow": "Seguir",
+  "user_profile_following": "Seguint",
+  "user_profile_pending": "Pendent",
 
   "general_home": "Pàgina principal",
   "general_loading": "Carregant...",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -27,6 +27,7 @@
   "route_detail_followers": "follower",
   "route_detail_followers_plural": "followers",
   "route_detail_following": "Following",
+  "route_detail_pending": "Pending",
   "route_detail_follow": "Follow",
   "route_detail_description_title": "Description",
   "route_detail_stages_title": "Route Stages",
@@ -64,6 +65,9 @@
   "profile_public_error_not_found": "User not found",
   "profile_public_error_loading": "Could not load profile.",
   "profile_public_login_follow_hint": "You must log in to follow users",
+  "user_profile_follow": "Follow",
+  "user_profile_following": "Following",
+  "user_profile_pending": "Pending",
 
   "general_home": "Home Page",
   "general_loading": "Loading...",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -27,6 +27,7 @@
   "route_detail_followers": "seguidor",
   "route_detail_followers_plural": "seguidores",
   "route_detail_following": "Siguiendo",
+  "route_detail_pending": "Pendiente",
   "route_detail_follow": "Seguir",
   "route_detail_description_title": "Descripción",
   "route_detail_stages_title": "Etapas de la Ruta",
@@ -64,6 +65,9 @@
   "profile_public_error_not_found": "Usuario no encontrado",
   "profile_public_error_loading": "No se ha podido cargar el perfil.",
   "profile_public_login_follow_hint": "Debes iniciar sesión para seguir usuarios",
+  "user_profile_follow": "Seguir",
+  "user_profile_following": "Siguiendo",
+  "user_profile_pending": "Pendiente",
 
   "general_home": "Página principal",
   "general_loading": "Cargando...",

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -62,18 +62,18 @@ export default function Home() {
       setCurrentUser(user);
 
       if (user) {
-        const backendInfo = await getUserById(user.uid);
-        setBackendUser(backendInfo);
+        try {
+          const backendInfo = await getUserById(user.uid);
+          setBackendUser(backendInfo);
+        } catch (err) {
+          console.error('Error loading backend user:', err);
+          setBackendUser(null);
+        }
       } else {
         setBackendUser(null);
       }
     });
 
-    return () => unsubscribe();
-  }, []);
-
-  useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, (user) => setCurrentUser(user));
     return () => unsubscribe();
   }, []);
 
@@ -88,23 +88,82 @@ export default function Home() {
       try {
         setLoading(true);
         const data = await getAllTrips(true);
-        setTrips(data);
+        
+        // Si no hi ha usuari loguejat, mostrar només les rutes de perfils públics
+        if (!currentUser) {
+          const filteredData = await Promise.all(
+            data.map(async (trip) => {
+              const authorId = trip.author?.userId;
+              if (!authorId) return trip;
+
+              try {
+                const author = await getUserById(authorId);
+                // Si el perfil és privat, ocultar la ruta
+                if (author?.isPrivate) {
+                  return null;
+                }
+                return trip;
+              } catch {
+                return trip;
+              }
+            })
+          );
+          setTrips(filteredData.filter((trip) => trip !== null) as Trip[]);
+          return;
+        }
+
+        // Si hi ha usuari loguejat, filtrar segons bloquejats i privats
+        const filteredData = await Promise.all(
+          data.map(async (trip) => {
+            const authorId = trip.author?.userId;
+            if (!authorId) return trip;
+
+            try {
+              // Comprovar si l'usuari m'ha bloquejat
+              const bloquejatsForm = backendUser?.llista_bloquejadors || [];
+              if (bloquejatsForm.includes(authorId)) {
+                return null;
+              }
+
+              // Comprovar si jo he bloquejat l'usuari
+              const bloquejats = backendUser?.llista_bloquejats || [];
+              if (bloquejats.includes(authorId)) {
+                return null;
+              }
+
+              const author = await getUserById(authorId);
+              
+              // Si el perfil és privat i no el segueixo i no sóc jo, ocultar la ruta
+              if (author?.isPrivate) {
+                const seguits = backendUser?.llista_seguits || [];
+                const isOwner = currentUser?.uid === authorId;
+                
+                // Si no segueixo i no sóc propietari, retornar null
+                if (!isOwner && !seguits.includes(authorId)) {
+                  return null;
+                }
+              }
+              
+              return trip;
+            } catch {
+              return trip;
+            }
+          })
+        );
+        
+        // Eliminar les rutes null
+        setTrips(filteredData.filter((trip) => trip !== null) as Trip[]);
       } catch {
         setError(t('home_error_loading_routes'));
       } finally {
         setLoading(false);
       }
     };
+    
     fetchTrips();
-  }, []);
+  }, [currentUser, backendUser, t]);
 
     const filteredTrips = trips
-        // Eliminem les rutes dels usuaris que tenim bloquejats
-        .filter((t) => {
-            const authorId = t.author?.userId;
-            const bloquejats = backendUser?.llista_bloquejats || [];
-            return !bloquejats.includes(authorId);
-        })
 
         // Mostrem les rutes dels usuaris que no seguim
         .filter((t) => {

--- a/frontend/src/pages/RutaDetall.tsx
+++ b/frontend/src/pages/RutaDetall.tsx
@@ -27,6 +27,7 @@ import {
   unfollowUser,
   saveTrip,
   unsaveTrip,
+  cancel_follow_request,
 } from "../api/client";
 
 import "dayjs/locale/ca";
@@ -50,10 +51,15 @@ export default function RutaDetall() {
 
   const [followersCount, setFollowersCount] = useState<number | null>(null);
   const [isFollowing, setIsFollowing] = useState(false);
+  const [isPending, setIsPending] = useState(false);
+  const [isPrivate, setIsPrivate] = useState(false);
   const [followLoading, setFollowLoading] = useState(false);
 
   const [isSaved, setIsSaved] = useState(false);
   const [saveLoading, setSaveLoading] = useState(false);
+
+  const [isBlocked, setIsBlocked] = useState(false);
+  const [imBlocked, setImBlocked] = useState(false);
 
 
   // 🔹 Carregar usuari Firebase + backendUser
@@ -82,7 +88,7 @@ export default function RutaDetall() {
     navigate("/");
   };
 
-  // 🔹 Carregar ruta
+  // 🔹 Carregar ruta + Comprovar accés
   useEffect(() => {
     const fetchTrip = async () => {
       if (!id) {
@@ -94,28 +100,72 @@ export default function RutaDetall() {
       try {
         setLoading(true);
 
+        let tripData: Trip | null = null;
+
         if (isMongoObjectId(id)) {
           const data = await getTripById(id);
-          setTripData(data);
+          tripData = data;
           setMainImage(data.coverImage || data.gallery?.[0] || "");
         } else if (isNumericIndex(id)) {
           const trips = await getAllTrips(false);
           const idx = parseInt(id) - 1;
 
           const tripAtIndex = trips[idx];
-          if (tripAtIndex?._id)
+          if (tripAtIndex?._id) {
             navigate(`/ruta/${tripAtIndex._id}`, { replace: true });
+            return;
+          }
         } else {
           setError(t('route_detail_error_id_invalid'));
+          return;
         }
+
+        // Comprovar accés a la ruta
+        if (tripData && tripData.author?.userId) {
+          const author = await getUserById(tripData.author.userId);
+
+          // Si hi ha usuari loguejat, comprovar bloqueigs i privacitat
+          if (currentUser) {
+            const currentUserData = await getUserById(currentUser.uid);
+            const isOwner = currentUser.uid === tripData.author.userId;
+
+            // Comprovar si he bloquejat l'autor
+            const bloquejats = currentUserData.llista_bloquejats || [];
+            const amBlocked = bloquejats.includes(tripData.author.userId);
+
+            // Comprovar si l'autor m'ha bloquejat
+            const imBlockedList = author.llista_bloquejats || [];
+            const authorBlockedMe = imBlockedList.includes(currentUser.uid);
+
+            // Si jo he bloquejat o l'autor m'ha bloquejat
+            if (!isOwner && (amBlocked || authorBlockedMe)) {
+              setError(t('route_detail_error_not_found'));
+              return;
+            }
+
+            // Si el perfil és privat i no segueixo
+            const followersList: string[] = author.llista_seguidors || [];
+            const isFollowingNow = followersList.includes(currentUser.uid);
+
+            if (!isOwner && author.isPrivate && !isFollowingNow) {
+              setError(t('route_detail_error_not_found'));
+              return;
+            }
+          }
+        }
+
+        setTripData(tripData);
       } catch {
         setError(t('route_detail_error_loading'));
       } finally {
         setLoading(false);
       }
     };
-    fetchTrip();
-  }, [id, navigate]);
+    
+    if (currentUser !== undefined) {
+      fetchTrip();
+    }
+  }, [id, navigate, currentUser, t]);
 
   // 🔹 Dades de l'autor
   useEffect(() => {
@@ -131,14 +181,31 @@ export default function RutaDetall() {
           : 0;
 
         setFollowersCount(count);
+        setIsPrivate(author.isPrivate || false);
 
         if (currentUser) {
           const followersList: string[] = author.llista_seguidors || [];
-          setIsFollowing(followersList.includes(currentUser.uid));
+          const isFollowingNow = followersList.includes(currentUser.uid);
+          setIsFollowing(isFollowingNow);
+
+          // Comprovar si hi ha sol·licitud de seguiment pendent
+          const solicituds = author.llista_solicitud_seguidors || [];
+          const hasSolicited = solicituds.includes(currentUser.uid);
+          setIsPending(hasSolicited && !isFollowingNow);
 
           const currentUserData = await getUserById(currentUser.uid);
           const savedTrips: string[] = currentUserData.guardades || [];
           setIsSaved(savedTrips.includes(tripData._id));
+
+          // Comprovar si he bloquejat l'autor
+          const bloquejats = currentUserData.llista_bloquejats || [];
+          const amBlocked = bloquejats.includes(tripData.author.userId);
+          setIsBlocked(amBlocked);
+
+          // Comprovar si l'autor m'ha bloquejat
+          const imBlockedList = author.llista_bloquejats || [];
+          const authorBlockedMe = imBlockedList.includes(currentUser.uid);
+          setImBlocked(authorBlockedMe);
         }
       } catch (e) {
         console.error(t('route_detail_error_author_data'), e);
@@ -158,14 +225,26 @@ export default function RutaDetall() {
     try {
       setFollowLoading(true);
 
-      if (!isFollowing) {
+      if (!isFollowing && !isPending) {
+        // Seguir l'usuari
         await followUser(userId, targetId);
-        setIsFollowing(true);
-        setFollowersCount((v) => (v ?? 0) + 1);
-      } else {
+        
+        // Si és privat, mostrar pendent; si és públic, mostrar following
+        if (isPrivate) {
+          setIsPending(true);
+        } else {
+          setIsFollowing(true);
+          setFollowersCount((v) => (v ?? 0) + 1);
+        }
+      } else if (isFollowing) {
+        // Deixar de seguir
         await unfollowUser(userId, targetId);
         setIsFollowing(false);
         setFollowersCount((v) => Math.max(0, (v ?? 0) - 1));
+      } else if (isPending) {
+        // Cancelar sol·licitud pendent
+        await cancel_follow_request(userId, targetId);
+        setIsPending(false);
       }
     } catch (err) {
       console.error(t('route_detail_error_following'), err);
@@ -239,7 +318,7 @@ export default function RutaDetall() {
   if (loading) return <div className="loading">{t('general_loading_route')}</div>;
   if (error || !tripData)
     return (
-      <div className="error">
+      <div className="error" style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', minHeight: '100vh', textAlign: 'center', gap: '20px' }}>
         <p>{error || t('route_detail_error_not_found')}</p>
         <button onClick={() => navigate(-1)}>← {t('route_detail_back')}</button>
       </div>
@@ -364,13 +443,13 @@ export default function RutaDetall() {
             )}
           </div>
 
-          {currentUser && currentUser.uid !== tripData.author.userId && (
+          {currentUser && currentUser.uid !== tripData.author.userId && !imBlocked && (
             <button
-              className={`follow-button ${isFollowing ? "following" : ""}`}
-              disabled={followLoading}
+              className={`follow-button ${isFollowing ? "following" : isPending ? "pending" : ""}`}
+              disabled={followLoading || isBlocked}
               onClick={handleFollow}
             >
-              {isFollowing ? t('route_detail_following') : t('route_detail_follow')}
+              {isFollowing ? t('route_detail_following') : isPending ? t('route_detail_pending') : t('route_detail_follow')}
             </button>
           )}
         </div>

--- a/frontend/src/pages/UserProfile.tsx
+++ b/frontend/src/pages/UserProfile.tsx
@@ -70,10 +70,34 @@ export default function UserProfile() {
   const [tripToDelete, setTripToDelete] = useState<string | null>(null);
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [mailboxOpen, setMailboxOpen] = useState(false);
-  const { notifications, loading: notifLoading, markRead } = useNotifications();
+  const {
+    notifications,
+    markRead,
+    refreshNotifications,
+    removeLocal,
+  } = useNotifications();
 
 
   const navigate = useNavigate();
+
+  const refreshProfile = async () => {
+    if (!currentUser) return;
+    try {
+      const updatedProfile = await getUserById(currentUser.uid);
+      updatedProfile.llista_seguidors = updatedProfile.llista_seguidors || [];
+      updatedProfile.llista_seguits = updatedProfile.llista_seguits || [];
+      updatedProfile.llista_solicitud_seguidors = updatedProfile.llista_solicitud_seguidors || [];
+      updatedProfile.llista_solicitud_seguits = updatedProfile.llista_solicitud_seguits || [];
+      updatedProfile.publicacions = updatedProfile.publicacions || [];
+      updatedProfile.guardades = updatedProfile.guardades || [];
+      updatedProfile.llista_bloquejats = updatedProfile.llista_bloquejats || [];
+      updatedProfile.llista_bloquejadors = updatedProfile.llista_bloquejadors || [];
+
+      setProfile(updatedProfile as BackendUser);
+    } catch (err) {
+      console.error("Error refrescant el perfil", err);
+    }
+  };
 
   // ---------------------------
   // Carregar usuari i trips
@@ -162,20 +186,20 @@ export default function UserProfile() {
   };
 
   const toGridItems = (trips: Trip[]): GridItem[] =>
-    trips.map((t) => ({
-      id: String(t._id),
-      title: t.title || t('general_no_title'),
+    trips.map((trip) => ({
+      id: String(trip._id),
+      title: trip.title || t('general_no_title'),
       img:
-        t.coverImage ||
-        (t.gallery && t.gallery[0]) ||
+        trip.coverImage ||
+        (trip.gallery && trip.gallery[0]) ||
         "https://placehold.co/600x400?text=Ruta+Sense+Imatge",
-      user: t.author?.name || t('general_anonymous'),
-      rating: typeof t.avgRating === "number" ? t.avgRating : 0,
-      temps: t.duration || "—",
-      dificultat: t.difficulty || "—",
-      authorPic: t.author?.profilePic || "",
-      city: t.city || "",
-      country: t.country || "",
+      user: trip.author?.name || t('general_anonymous'),
+      rating: typeof trip.avgRating === "number" ? trip.avgRating : 0,
+      temps: trip.duration || "—",
+      dificultat: trip.difficulty || "—",
+      authorPic: trip.author?.profilePic || "",
+      city: trip.city || "",
+      country: trip.country || "",
     }));
 
   const askDeleteTrip = (tripId: string) => {
@@ -249,6 +273,17 @@ export default function UserProfile() {
   
   const openMailbox = () => {
     setMailboxOpen(true);
+  };
+
+  const handleAfterAcceptNotification = async (notificationId: string) => {
+    removeLocal(notificationId);
+    await refreshNotifications();
+    await refreshProfile();
+  };
+
+  const handleAfterRejectNotification = async (notificationId: string) => {
+    removeLocal(notificationId);
+    await refreshNotifications();
   };
 
 
@@ -484,6 +519,8 @@ export default function UserProfile() {
             onClose={() => setMailboxOpen(false)}
             notifications={notifications}
             onMarkRead={markRead}
+            onAfterAccept={handleAfterAcceptNotification}
+            onAfterReject={handleAfterRejectNotification}
           />
 
 

--- a/frontend/src/pages/UserProfile.tsx
+++ b/frontend/src/pages/UserProfile.tsx
@@ -28,6 +28,10 @@ export type BackendUser = {
   seguits?: number;
   llista_seguidors?: string[];
   llista_seguits?: string[];
+  llista_solicitud_seguidors?: string[];
+  llista_solicitud_seguits?: string[];
+  llista_bloquejats?: string[];
+  llista_bloquejadors?: string[];
   publicacions?: string[];
   guardades?: string[];
   url_foto_perfil?: string;
@@ -89,6 +93,8 @@ export default function UserProfile() {
         const backendUser = await getUserById(fbUser.uid);
         backendUser.llista_seguidors = backendUser.llista_seguidors || [];
         backendUser.llista_seguits = backendUser.llista_seguits || [];
+        backendUser.llista_solicitud_seguidors = backendUser.llista_solicitud_seguidors || [];
+        backendUser.llista_solicitud_seguits = backendUser.llista_solicitud_seguits || [];
         backendUser.publicacions = backendUser.publicacions || [];
         backendUser.guardades = backendUser.guardades || [];
         backendUser.llista_bloquejats = backendUser.llista_bloquejats || [];

--- a/frontend/src/pages/UserProfile.tsx
+++ b/frontend/src/pages/UserProfile.tsx
@@ -32,6 +32,7 @@ export type BackendUser = {
   guardades?: string[];
   url_foto_perfil?: string;
   url_foto_panell?: string;
+  isPrivate?: boolean;
 };
 
 type GridItem = {
@@ -62,9 +63,6 @@ export default function UserProfile() {
   const [seguitsModalOpen, setSeguitsModalOpen] = useState(false);
   const [seguidoresModalOpen, setSeguidoresModalOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
-
-
-  // 🗑️ estat per al popup d’eliminació
   const [tripToDelete, setTripToDelete] = useState<string | null>(null);
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [mailboxOpen, setMailboxOpen] = useState(false);
@@ -174,7 +172,6 @@ export default function UserProfile() {
       country: t.country || "",
     }));
 
-  // 🗑️ Quan fas clic a la brossa: només obrim el popup
   const askDeleteTrip = (tripId: string) => {
     setTripToDelete(tripId);
     setDeleteModalOpen(true);
@@ -191,7 +188,6 @@ export default function UserProfile() {
         prev.filter((t) => String(t._id) !== String(tripToDelete))
       );
 
-      // Treure-la de publicacions del perfil
       setProfile((prev) =>
         prev
           ? {
@@ -211,7 +207,6 @@ export default function UserProfile() {
     }
   };
 
-  // ❌ Cancel·lar popup
   const handleCancelDeleteTrip = () => {
     setDeleteModalOpen(false);
     setTripToDelete(null);
@@ -410,7 +405,12 @@ export default function UserProfile() {
               goToProfile={goToProfile} 
             />
           )}
-          <UserSettings open={settingsOpen} onClose={() => setSettingsOpen(false)} />
+          <UserSettings 
+            open={settingsOpen} 
+            onClose={() => setSettingsOpen(false)}
+            profile={profile}
+            onSavePrivacy={(updatedProfile) => setProfile(updatedProfile)}
+          />
 
           {openEdit && profile && (
             <EditarPerfil

--- a/frontend/src/pages/UserProfilePublic.tsx
+++ b/frontend/src/pages/UserProfilePublic.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { onAuthStateChanged, type User as FirebaseUser, signOut } from "firebase/auth";
 import { useNavigate, useParams } from "react-router-dom";
 import { auth } from "../firebase";
-import { getUserById, followUser, unfollowUser, blockUser, unblockUser } from "../api/client";
+import { getUserById, followUser, unfollowUser, blockUser, unblockUser, cancel_follow_request } from "../api/client";
 import { getAllTrips, type Trip } from "../api/trips";
 import "../styles/UserProfile.css";
 import { ImageOff, UserX } from "lucide-react";
@@ -27,9 +27,12 @@ export type BackendUser = {
   publicacions?: string[];
   url_foto_perfil?: string;
   url_foto_panell?: string;
+  isPrivate?: boolean;
   llista_bloquejats?: string[];
   llista_bloquejadors?: string[];
 };
+
+type FollowStatus = "none" | "pending" | "following";
 
 export default function UserProfilePublic() {
   const { t } = useTranslation();
@@ -47,6 +50,7 @@ export default function UserProfilePublic() {
 
   const [isFollowing, setIsFollowing] = useState(false);
   const [followLoading, setFollowLoading] = useState(false);
+  const [followStatus, setFollowStatus] = useState<FollowStatus>("none");
 
   // Estats de bloqueig (Staging)
   const [isBlocked, setIsBlocked] = useState(false);
@@ -106,14 +110,19 @@ export default function UserProfilePublic() {
     fetchProfile();
   }, [id, t]);
 
-  // Saber si el seguim
+  // Saber si el currentUser segueix aquest perfil
   useEffect(() => {
     if (!currentUser || !profile) {
       setIsFollowing(false);
+      setFollowStatus("none");
       return;
     }
+
     const followers = profile.llista_seguidors || [];
-    setIsFollowing(followers.includes(currentUser.uid));
+    const alreadyFollowing = followers.includes(currentUser.uid);
+
+    setIsFollowing(alreadyFollowing);
+    setFollowStatus(alreadyFollowing ? "following" : "none");
   }, [currentUser, profile]);
 
   // Saber si l'hem bloquejat (Staging)
@@ -145,6 +154,8 @@ export default function UserProfilePublic() {
       return;
     }
     if (!profile) return;
+
+    const isPrivateProfile = !!profile.isPrivate;
     if (isBlocked) return alert("No pots seguir un usuari que has bloquejat."); 
 
     try {
@@ -152,22 +163,44 @@ export default function UserProfilePublic() {
       const userId = currentUser.uid;
       const targetId = profile.uid;
 
-      if (!isFollowing) {
+      // Si no segueix, intentar seguir
+      if (followStatus === "none") {
         await followUser(userId, targetId);
-        setIsFollowing(true);
-        setProfile((prev) =>
-          prev
-            ? { ...prev, llista_seguidors: [...(prev.llista_seguidors || []), userId] }
-            : prev
-        );
-      } else {
+        
+        // Actualitzar estat segons si el perfil és privat o públic
+        if (isPrivateProfile) {
+          // Perfil privat → estat pending
+          setFollowStatus("pending");
+        } else {
+          // Perfil públic → estat following
+          setIsFollowing(true);
+          setFollowStatus("following");
+          setProfile((prev) =>
+            prev
+              ? { ...prev, llista_seguidors: [...(prev.llista_seguidors || []), userId] }
+              : prev
+          );
+        }
+      } else if (followStatus === "following") {
+        // Si ja segueix, deixar de seguir
         await unfollowUser(userId, targetId);
         setIsFollowing(false);
+        setFollowStatus("none");
+
         setProfile((prev) =>
           prev
-            ? { ...prev, llista_seguidors: (prev.llista_seguidors || []).filter((uid) => uid !== userId) }
+            ? {
+                ...prev,
+                llista_seguidors: (prev.llista_seguidors || []).filter(
+                  (uid) => uid !== userId
+                ),
+              }
             : prev
         );
+      } else if (followStatus === "pending") {
+        // Si la sol·licitud està pending, cancel·lar-la
+        await cancel_follow_request(userId, targetId);
+        setFollowStatus("none");
       }
     } catch (err) {
       console.error(t('profile_error_unfollowing'), err);
@@ -235,7 +268,18 @@ export default function UserProfilePublic() {
     }
   };
 
+  // Convertir Trips → items de grid
   const publicacionsItems = useMemo(() => {
+
+    // Determinar si puc veure les publicacions del perfil
+    const isOwner = currentUser?.uid === profile?.uid;
+    const isProfilePrivate = !!profile?.isPrivate;
+    
+    // Si el perfil és privat i no sóc propietari ni segueixo, no mostrar rutes
+    if (isProfilePrivate && !isOwner && !isFollowing) {
+      return [];
+    }
+
     const pubIds = new Set((profile?.publicacions || []).map(String));
     return trips
       .filter((t) => pubIds.has(String(t._id)))
@@ -276,6 +320,26 @@ export default function UserProfilePublic() {
     await signOut(auth);
     navigate("/");
   };
+  
+  const isPrivate = !!profile?.isPrivate;
+
+  // Text i estil del botó segons estat
+  const buttonLabel = (() => {
+    if (isPrivate) {
+      if (followStatus === "pending") return "Pendent";
+      if (followStatus === "following") return "Seguint";
+      return "Seguir";
+    }
+    return isFollowing ? "Seguint" : "Seguir";
+  })();
+
+  const buttonClass = `follow-button ${
+    isPrivate && followStatus === "pending"
+      ? "pending"
+      : isFollowing || followStatus === "following"
+      ? "following"
+      : ""
+  }`;
 
   return (
     <Layout
@@ -347,11 +411,11 @@ export default function UserProfilePublic() {
 
                 {currentUser && currentUser.uid !== profile.uid && !imBlocked && (
                   <button
-                    className={`follow-button ${isFollowing ? "following" : ""}`}
+                    className={buttonClass}
                     disabled={followLoading || isBlocked}
                     onClick={handleFollow}
                   >
-                    {isFollowing ? t('route_detail_following') : t('route_detail_follow')}
+                    {buttonLabel}
                   </button>
                 )}
               </div>

--- a/frontend/src/pages/UserProfilePublic.tsx
+++ b/frontend/src/pages/UserProfilePublic.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { onAuthStateChanged, type User as FirebaseUser, signOut } from "firebase/auth";
 import { useNavigate, useParams } from "react-router-dom";
 import { auth } from "../firebase";
-import { getUserById, followUser, unfollowUser, blockUser, unblockUser, cancel_follow_request } from "../api/client";
+import { getUserById, followUser, unfollowUser, blockUser, unblockUser, cancel_follow_request, askToFollowUser } from "../api/client";
 import { getAllTrips, type Trip } from "../api/trips";
 import "../styles/UserProfile.css";
 import { ImageOff, UserX } from "lucide-react";
@@ -30,6 +30,8 @@ export type BackendUser = {
   isPrivate?: boolean;
   llista_bloquejats?: string[];
   llista_bloquejadors?: string[];
+  llista_solicitud_seguidors?: string[];
+  llista_solicitud_seguits?: string[];
 };
 
 type FollowStatus = "none" | "pending" | "following";
@@ -90,6 +92,8 @@ export default function UserProfilePublic() {
         backendUser.publicacions = backendUser.publicacions || [];
         backendUser.llista_bloquejats = backendUser.llista_bloquejats || [];
         backendUser.llista_bloquejadors = backendUser.llista_bloquejadors || [];
+        backendUser.llista_solicitud_seguidors = backendUser.llista_solicitud_seguidors || [];
+        backendUser.llista_solicitud_seguits = backendUser.llista_solicitud_seguits || [];
 
         setProfile(backendUser as BackendUser);
 
@@ -110,7 +114,7 @@ export default function UserProfilePublic() {
     fetchProfile();
   }, [id, t]);
 
-  // Saber si el currentUser segueix aquest perfil
+  // Saber si el currentUser segueix aquest perfil o ha solicitat seguir-lo
   useEffect(() => {
     if (!currentUser || !profile) {
       setIsFollowing(false);
@@ -119,10 +123,18 @@ export default function UserProfilePublic() {
     }
 
     const followers = profile.llista_seguidors || [];
-    const alreadyFollowing = followers.includes(currentUser.uid);
+    const pendingRequests = profile.llista_solicitud_seguidors || [];
 
-    setIsFollowing(alreadyFollowing);
-    setFollowStatus(alreadyFollowing ? "following" : "none");
+    if (followers.includes(currentUser.uid)) {
+      setIsFollowing(true);
+      setFollowStatus("following");
+    } else if (pendingRequests.includes(currentUser.uid)) {
+      setIsFollowing(false);
+      setFollowStatus("pending");
+    } else {
+      setIsFollowing(false);
+      setFollowStatus("none");
+    }
   }, [currentUser, profile]);
 
   // Saber si l'hem bloquejat (Staging)
@@ -165,15 +177,15 @@ export default function UserProfilePublic() {
 
       // Si no segueix, intentar seguir
       if (followStatus === "none") {
-        await followUser(userId, targetId);
         
         // Actualitzar estat segons si el perfil és privat o públic
         if (isPrivateProfile) {
           // Perfil privat → estat pending
+          await askToFollowUser(userId, targetId);
           setFollowStatus("pending");
         } else {
           // Perfil públic → estat following
-          setIsFollowing(true);
+          await followUser(userId, targetId);
           setFollowStatus("following");
           setProfile((prev) =>
             prev

--- a/frontend/src/styles/LoginReg.css
+++ b/frontend/src/styles/LoginReg.css
@@ -238,6 +238,41 @@
   color: #2e492e;
 }
 
+/* ---------- Privacitat del perfil ---------- */
+.privacy-section {
+  margin-top: 0.75rem;
+  text-align: left;
+  width: 100%;
+  max-width: 320px;
+}
+
+.privacy-title {
+  display: block;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #2e492e;
+  margin-bottom: 0.35rem;
+}
+
+.privacy-options {
+  display: flex;
+  gap: 1.2rem;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.privacy-option {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  cursor: pointer;
+}
+
+.privacy-option input {
+  accent-color: #356a36; /* verd coherent amb el branding */
+}
+
+
 /* ---------- FLOATING LABEL INPUTS ---------- */
 
 .floating-input-group {

--- a/frontend/src/styles/RutaDetall.header-actions.css
+++ b/frontend/src/styles/RutaDetall.header-actions.css
@@ -204,6 +204,12 @@
   border-color: #2e7d32;
 }
 
+.follow-button.pending {
+  background-color: #9e9e9e;
+  color: white;
+  border-color: #9e9e9e;
+}
+
 .follow-button:disabled {
   opacity: 0.6;
   cursor: default;

--- a/frontend/src/styles/RutaDetalls.css
+++ b/frontend/src/styles/RutaDetalls.css
@@ -574,6 +574,13 @@
   border-color: #2e7d32;
 }
 
+/* Estat quan la sol·licitud està pending (perfil privat) */
+.follow-button.pending {
+  background-color: #9e9e9e !important;
+  color: white !important;
+  border-color: #9e9e9e;
+}
+
 .follow-button:disabled {
   opacity: 0.6;
   cursor: default;

--- a/frontend/src/styles/UserProfile.css
+++ b/frontend/src/styles/UserProfile.css
@@ -403,6 +403,15 @@
   }
 }
 
+<<<<<<< HEAD
+=======
+<<<<<<< HEAD
+
+/* =========================================================
+   RESPONSIVE
+   ========================================================= */
+=======
+>>>>>>> US-4.1.1
 /* BOTÓN BLOQUEAR ARRIBA DERECHA (ICONO REDONDO) */
 .block-button {
   position: absolute;
@@ -440,6 +449,10 @@
 }
 
 /* RESPONSIVE*/
+<<<<<<< HEAD
+=======
+>>>>>>> staging
+>>>>>>> US-4.1.1
    
 /* Versión responsive */
 @media (max-width: 600px) {

--- a/frontend/src/styles/UserSettings.css
+++ b/frontend/src/styles/UserSettings.css
@@ -102,6 +102,12 @@
   gap: 0.2rem;
 }
 
+.settings-row-helper {
+  font-size: 0.8rem;      
+  color: #777777;
+  line-height: 1.3;
+}
+
 .settings-row-label {
   font-weight: 500;
   color: #333333;


### PR DESCRIPTION
Quan un usuari es registra, ara aquest pot escollir la possibilitat de fer el seu perfil privat. Si ho fa, les seves publicacions no seran visibles per la resta d'usuaris si no el segueixen, ni a la pàgina principal ni dins del perfil. 

Hem canviat la interacció de seguiment per aquests perfils: en comptes de que els usuaris els segueixin automàticament en prémer el botó corresponent, es genera una sol·licitud de seguiment que s'envia a la bústia de notificacions del propietari del perfil, que pot reaccionar de la següent manera:
- Mentre no fa res, l'estat de l'acció queda com a pendent. 
- Si accepta la sol·licitud, l'usuari sol·licitant el comença a seguir i rep una notificació confirmant-ho.
- Si rebutja la sol·licitud, s'elimina la notificació i el perfil segueix ocult pel sol·licitant.

També es pot canviar la privacitat del perfil des de la configuració.